### PR TITLE
Fix Coloring Bar, Coloring Clear and add toggle coloring mode (t)

### DIFF
--- a/src/sudoku/CellZoomPanel.java
+++ b/src/sudoku/CellZoomPanel.java
@@ -54,7 +54,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	private static final int DIFF_SIZE = 1;
 	private static final String[] NUMBERS = new String[] { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 	private static final int COLOR_BUTTON_COUNT = 12;
-	
+
 	private MainFrame mainFrame;
 	private Font buttonFont = null;
 	private Font iconFont = null;
@@ -70,7 +70,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	private int colorImageHeight = -1;
 	private Icon[] colorKuIcons = new Icon[9];
 	private boolean isInitialized = false;
-	
+
 	private javax.swing.JPanel chooseColorPanel;
 	private javax.swing.JButton jFontButton;
 	private javax.swing.JPanel jPanel1;
@@ -89,19 +89,19 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 
 	/**
 	 * Creates new form CellZoomPanel
-	 * 
+	 *
 	 * @param mainFrame
 	 */
 	public CellZoomPanel(MainFrame mainFrame) {
-		
+
 		this.mainFrame = mainFrame;
-		
+
 		cellPanels = new JPanel[COLOR_BUTTON_COUNT];
-		setValueButtons = new JButton[Sudoku2.UNITS];		
+		setValueButtons = new JButton[Sudoku2.UNITS];
 		toggleCandidatesButtons = new JButton[Sudoku2.UNITS];
-		
+
 		initComponents();
-		
+
 		JButton defaultButton = new JButton();
 		normButtonForeground = defaultButton.getForeground();
 		normButtonBackground = defaultButton.getBackground();
@@ -117,18 +117,18 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		if (getFont().getSize() > 12) {
 			fontSize = getFont().getSize();
 		}
-		
+
 		Font font = titleLabel.getFont();
 		titleLabel.setFont(new Font(font.getName(), Font.BOLD, fontSize));
-		
+
 		isInitialized = true;
 		calculateLayout();
 	}
-	
+
 	private JPanel createColorButtonPanel(int id) {
-		
+
 		JPanel panel = new StatusColorPanel(id);
-		
+
 		panel.addMouseListener(new java.awt.event.MouseAdapter() {
 			public void mousePressed(java.awt.event.MouseEvent evt) {
 				chooseCellColorPanelMouseClicked(evt);
@@ -153,18 +153,18 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		toggleCandidatesPanel = new javax.swing.JPanel();
 		chooseColorPanel = new javax.swing.JPanel();
 		jFontButton = new javax.swing.JButton();
-		
+
 		colorPalette = new UIColorPalette(this);
 		add(colorPalette);
-		
+
 		colorTools = new UIColorTools();
 		add(colorTools);
-		
+
 		ResourceBundle bundle = java.util.ResourceBundle.getBundle("intl/CellZoomPanel");
 		String defaultText = bundle.getString("CellZoomPanel.radioButtonDefault.text");
 		String colorCandidatesText = bundle.getString("CellZoomPanel.radioButtonColorCandidates.text");
 		String colorCellsText = bundle.getString("CellZoomPanel.radioButtonColorCells.text");
-		
+
 		radioButtonPanel = new JPanel(new GridLayout(3, 1));
 		radioButtonPanel.setSize(130, colorPalette.getHeight());
 		radioButtonGroup = new ButtonGroup();
@@ -211,7 +211,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 
 		// initialize all set value buttons
 		for (int index = 0; index < Sudoku2.UNITS; index++) {
-			
+
 			setValueButtons[index] = new JButton();
 			setValueButtons[index].setText(NUMBERS[index]);
 			setValueButtons[index].addActionListener(new java.awt.event.ActionListener() {
@@ -219,7 +219,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 					setValueButtonActionPerformed(evt);
 				}
 			});
-			
+
 			setValuePanel.add(setValueButtons[index]);
 		}
 
@@ -233,7 +233,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 
 		// initialize all toggle candidate buttons
 		for (int index = 0; index < Sudoku2.UNITS; index++) {
-			
+
 			toggleCandidatesButtons[index] = new JButton();
 			toggleCandidatesButtons[index].setText(NUMBERS[index]);
 			toggleCandidatesButtons[index].addActionListener(new java.awt.event.ActionListener() {
@@ -241,22 +241,22 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 					toggleCandidatesButtonActionPerformed(evt);
 				}
 			});
-			
+
 			toggleCandidatesPanel.add(toggleCandidatesButtons[index]);
 		}
 
 		add(toggleCandidatesPanel);
 		toggleCandidatesPanel.setBounds(0, 0, 117, 69);
 		chooseColorPanel.setLayout(new java.awt.GridLayout(2, 6, 1, 1));
-		
+
 		for (int i = 0; i < COLOR_BUTTON_COUNT; i++) {
 			cellPanels[i] = createColorButtonPanel(i);
 		}
-		
+
 		for (int i = 0; i < COLOR_BUTTON_COUNT; i += 2) {
 			chooseColorPanel.add(cellPanels[i]);
 		}
-		
+
 		for (int i = 1; i < COLOR_BUTTON_COUNT; i += 2) {
 			chooseColorPanel.add(cellPanels[i]);
 		}
@@ -288,16 +288,16 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	}
 
 	private void onToggleCandidate(JButton button) {
-		
+
 		int candidate = -1;
-		
+
 		for (int i = 0; i < toggleCandidatesButtons.length; i++) {
 			if (button == toggleCandidatesButtons[i]) {
 				candidate = i + 1;
 				break;
 			}
 		}
-		
+
 		if (sudokuPanel != null && candidate != -1) {
 			if (isDefaultMouse()) {
 				sudokuPanel.toggleCandidateFromCellSelection(candidate);
@@ -309,26 +309,30 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	}
 
 	private void setValue(JButton button) {
-		
+
 		int number = -1;
-		
+
 		for (int i = 0; i < setValueButtons.length; i++) {
 			if (button == setValueButtons[i]) {
 				number = i + 1;
 				break;
 			}
 		}
-		
+
 		if (sudokuPanel != null && number != -1) {
 			sudokuPanel.setCellFromCellZoomPanel(number);
 		}
 	}
 
+	public void setPrimaryColor(Color color) {
+		colorPalette.setPrimaryColor(color);
+	}
+
 	private void handleColorChange(JPanel panel, boolean isCtrlDown) {
-		
+
 		boolean found = false;
 		int colorNumber = -1;
-		
+
 		for (int i = 0; i < cellPanels.length; i++) {
 			if (panel == cellPanels[i]) {
 				colorNumber = i;
@@ -336,12 +340,12 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 				break;
 			}
 		}
-		
+
 		if (colorNumber >= 0 && !isCtrlDown) {
 			Color color = Options.getInstance().getColoringColors()[colorNumber];
 			colorPalette.setPrimaryColor(color);
 		}
-		
+
 		if (found && mainFrame != null) {
 			if (isCtrlDown && colorNumber > 0) {
 				if (isColoringCells()) {
@@ -359,17 +363,17 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 				}
 			}
 		}
-		
+
 		sudokuPanel.repaint();
 	}
 
 	public final void calculateLayout() {
-		
+
 		if (!isInitialized) {
 			// not yet initialized!
 			return;
 		}
-		
+
 		int width = getWidth();
 		int height = getHeight();
 		int y = Y_OFFSET;
@@ -389,22 +393,22 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		if (colorPanelHeight > COLOR_PANEL_MAX_HEIGHT) {
 			colorPanelHeight = COLOR_PANEL_MAX_HEIGHT;
 		}
-		
+
 		if (buttonPanelHeight > (width - 2 * X_OFFSET)) {
 			buttonPanelHeight = width - 2 * X_OFFSET;
 		}
-		
+
 		// adjust color panels
 		if (buttonPanelHeight < 120) {
 			colorPanelHeight -= (120 - buttonPanelHeight);
 			buttonPanelHeight = 120;
 		}
-		
+
 		int colorPanelGesWidth = colorPanelHeight * 4;
 		if (colorPanelGesWidth > width - 2 * X_OFFSET) {
 			colorPanelHeight = (int) ((width - 2 * X_OFFSET) / 4.5);
 		}
-		
+
 		colorPanelGesWidth = colorPanelHeight * 4;
 		int newColorImageHeight = colorPanelHeight * 2 / 3;
 
@@ -433,7 +437,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		radioButtonPanel.setLocation(colorPalette.getX() + colorPalette.getWidth() + 10, colorPalette.getY());
 		y += colorPalette.getHeight();
 		y += LARGE_GAP;
-		
+
 		chooseColorPanel.setSize(colorPanelHeight/2*COLOR_BUTTON_COUNT/2, colorPanelHeight);
 		chooseColorPanel.setLocation(setValuePanel.getX(), y);
 		chooseColorPanel.doLayout();
@@ -457,19 +461,19 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 				toggleCandidatesButtons[i].setFont(buttonFont);
 			}
 		}
-		
+
 		// ColorKu icons should be the same size as the candidate numbers
 		// icons are only created, if colorKu mode is active
-		if (newColorImageHeight > 0 && 
-			Options.getInstance().isShowColorKuAct() && 
+		if (newColorImageHeight > 0 &&
+			Options.getInstance().isShowColorKuAct() &&
 			newColorImageHeight != colorImageHeight) {
-			
+
 			colorImageHeight = newColorImageHeight;
 			for (int i = 0; i < colorKuIcons.length; i++) {
 				colorKuIcons[i] = new ImageIcon(new ColorKuImage(colorImageHeight, Options.getInstance().getColorKuColor(i + 1)));
 			}
 		}
-		
+
 		repaint();
 	}
 
@@ -490,7 +494,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	 * <li>if a set of cells is selected, coloredCells and coloredCandidates are
 	 * null</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param values
 	 * @param candidates
 	 * @param aktColor
@@ -501,13 +505,13 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	 * @param coloredCandidates
 	 */
 	public void update(
-			SudokuSet values, 
-			SudokuSet candidates, 
-			int index, 
-			boolean singleCell, 
+			SudokuSet values,
+			SudokuSet candidates,
+			int index,
+			boolean singleCell,
 			SortedMap<Integer, Color> coloredCells,
 			SortedMap<Integer, Color> coloredCandidates) {
-		
+
 		// reset all buttons
 		for (int i = 0; i < setValueButtons.length; i++) {
 			setValueButtons[i].setText("");
@@ -524,7 +528,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 
 		// now set accordingly
 		if (isDefaultMouse()) {
-			
+
 			// no coloring -> buttons are available
 			for (int i = 0; i < values.size(); i++) {
 				int cand = values.get(i) - 1;
@@ -539,7 +543,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 					setValueButtons[cand].setEnabled(true);
 				}
 			}
-			
+
 			for (int i = 0; i < candidates.size(); i++) {
 				int cand = candidates.get(i) - 1;
 				if (cand >= 0 && cand <= 8) {
@@ -553,7 +557,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 					toggleCandidatesButtons[cand].setEnabled(true);
 				}
 			}
-			
+
 			ResourceBundle bundle = ResourceBundle.getBundle("intl/CellZoomPanel");
 			if (singleCell) {
 				toggleCandidatesLabel.setText(bundle.getString("CellZoomPanel.toggleCandidatesLabel.text"));
@@ -563,10 +567,10 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 			} else {
 				toggleCandidatesLabel.setText(bundle.getString("CellZoomPanel.toggleCandidatesLabel.text2"));
 			}
-			
+
 		} else {
-			
-			// coloring			
+
+			// coloring
 			if (coloredCells != null) {
 
 				if (isColoringCells()) {
@@ -588,16 +592,16 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 	}
 
 	private ImageIcon createImage(int size, Color color, int cand) {
-		
+
 		if (size > 0) {
-			
+
 			Image img = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
 			Graphics2D g = (Graphics2D) img.getGraphics();
-			
+
 			if (color == null) {
 				color = Options.getInstance().getDefaultCellColor();
 			}
-			
+
 			g.setColor(color);
 			g.fillRect(0, 0, size, size);
 			if (cand > 0) {
@@ -615,7 +619,7 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 					g.drawString(String.valueOf(cand), (size - strWidth) / 2, (size + strHeight - 2) / 2);
 				}
 			}
-			
+
 			return new ImageIcon(img);
 		} else {
 			return null;
@@ -637,61 +641,78 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		this.colorPalette.setSudokuPanel(sudokuPanel);
 		this.colorTools.setSudokuPanel(sudokuPanel);
 	}
-	
+
 	public void swapColors() {
 		colorPalette.swap();
 		repaint();
 	}
-	
+
 	public boolean isDefaultMouse() {
 		return radioButtonDefault.isSelected();
 	}
-	
+
 	public boolean isColoringCells() {
 		return radioButtonColorCells.isSelected();
 	}
-	
+
 	public boolean isColoringCandidates() {
 		return radioButtonColorCandidates.isSelected();
 	}
-	
+
 	public boolean isColoring() {
 		return isColoringCells() || isColoringCandidates();
 	}
-	
+
+	public void nextColoringMode() {
+		if (radioButtonDefault.isSelected()) {
+			radioButtonColorCandidates.setSelected(true);
+			mainFrame.setColoring(getPrimaryColor(), false);
+		} else if (radioButtonColorCandidates.isSelected()) {
+			radioButtonColorCells.setSelected(true);
+			mainFrame.setColoring(getPrimaryColor(), true);
+		} else {
+			resetColoring();
+			mainFrame.setColoring(null, false);
+		}
+	}
+
+	public void resetColoring() {
+		setDefaultMouse(true);
+		radioButtonDefault.setSelected(true);
+	}
+
 	public void setDefaultMouse(boolean enable) {
 		if (!radioButtonDefault.isSelected() && enable) {
 			radioButtonDefault.setSelected(true);
 		}
 	}
-	
+
 	public void setColorCells(boolean enable) {
 		if (radioButtonColorCells.isSelected() && !enable) {
 			radioButtonDefault.setSelected(true);
 		} else if (!radioButtonColorCells.isSelected()) {
-			radioButtonDefault.setSelected(true);
+			radioButtonColorCells.setSelected(true);
 		}
 	}
-	
+
 	public void setColorCandidates(boolean enable) {
 		if (radioButtonColorCandidates.isSelected() && !enable) {
 			radioButtonDefault.setSelected(true);
 		} else if (!radioButtonColorCandidates.isSelected()) {
-			radioButtonDefault.setSelected(true);
+			radioButtonColorCandidates.setSelected(true);
 		}
 	}
-	
+
 	public Color getPrimaryColor() {
 		return colorPalette.getPrimaryColor();
 	}
-	
+
 	public Color getSecondaryColor() {
 		return colorPalette.getSecondaryColor();
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		
 		if (e.getSource() == radioButtonDefault) {
 			mainFrame.setColoring(null, false);
 		} else if (e.getSource() == radioButtonColorCells) {
@@ -699,8 +720,8 @@ public class CellZoomPanel extends JPanel implements ActionListener {
 		} else if (e.getSource() == radioButtonColorCandidates) {
 			mainFrame.setColoring(getPrimaryColor(), false);
 		}
-		
-		mainFrame.check();		
+
+		mainFrame.check();
 		mainFrame.repaint();
 	}
 }

--- a/src/sudoku/MainFrame.java
+++ b/src/sudoku/MainFrame.java
@@ -152,17 +152,17 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	private double saveImageDefaultSize = 800;
 	private int bildAufloesung = 96;
 	private int bildEinheit = 2;
-	
-	private MyFileFilter[] puzzleFileSaveFilters = new MyFileFilter[] { 
-		new MyFileFilter(1), new MyFileFilter(2), new MyFileFilter(3), 
-		new MyFileFilter(4), new MyFileFilter(5), new MyFileFilter(6), 
+
+	private MyFileFilter[] puzzleFileSaveFilters = new MyFileFilter[] {
+		new MyFileFilter(1), new MyFileFilter(2), new MyFileFilter(3),
+		new MyFileFilter(4), new MyFileFilter(5), new MyFileFilter(6),
 		new MyFileFilter(7), new MyFileFilter(9)
 	};
-	
-	private MyFileFilter[] puzzleFileLoadFilters = new MyFileFilter[] { 
+
+	private MyFileFilter[] puzzleFileLoadFilters = new MyFileFilter[] {
 		new MyFileFilter(1), new MyFileFilter(8), new MyFileFilter(9)
 	};
-	
+
 	private MyFileFilter[] configFileFilters = new MyFileFilter[] { new MyFileFilter(0) };
 	private MyCaretListener caretListener = new MyCaretListener();
 	private boolean outerSplitPaneInitialized = false; // used to adjust divider bar at startup!
@@ -354,7 +354,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * Incorporates the last subversion revision of this file into the version
 	 * string.<br>
 	 * <br>
-	 * 
+	 *
 	 * CAUTION: MainFrame.java must be changed and committed to change the build
 	 * number.
 	 */
@@ -365,7 +365,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 	/**
 	 * Creates new form MainFrame
-	 * 
+	 *
 	 * @param launchFile
 	 */
 	public MainFrame(String launchFile) {
@@ -387,7 +387,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		if (!Options.getInstance().checkFont(fontName)) {
 			fontName = Font.SANS_SERIF;
 		}
-		
+
 		Font font = hinweisTextArea.getFont();
 
 		font = new Font(fontName, font.getStyle(), editMenu.getFont().getSize());
@@ -400,12 +400,12 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		if (!Options.getInstance().checkFont(fontName)) {
 			fontName = font.getName();
 		}
-		
+
 		int fontSize = 12;
 		if (font.getSize() > fontSize) {
 			fontSize = font.getSize();
 		}
-		
+
 		font = new Font(fontName, getFont().getStyle(), fontSize);
 		statusLabelCellCandidate.setFont(font);
 		statusLabelLevel.setFont(font);
@@ -423,7 +423,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		if (lafMenuBackColor == null) {
 			lafMenuBackColor = Color.BLUE;
 		}
-		
+
 		if (lafMenuColor == null) {
 			lafMenuColor = Color.BLACK;
 		}
@@ -442,7 +442,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				adjustPasteMenuItem();
 			}
 		});
-		
+
 		try {
 			Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
 			clip.addFlavorListener(this);
@@ -473,35 +473,35 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		} else {
 			setWindowLayout(true);
 		}
-		
+
 		outerSplitPaneInitialized = false;
 		if (Options.getInstance().getInitialXPos() != -1 && Options.getInstance().getInitialYPos() != -1) {
-			
+
 			Toolkit t = Toolkit.getDefaultToolkit();
 			Dimension screenSize = t.getScreenSize();
-			
+
 			int x = Options.getInstance().getInitialXPos();
 			int y = Options.getInstance().getInitialYPos();
-			
+
 			if (x + getWidth() > screenSize.width) {
 				x = screenSize.width - getWidth() - 10;
 			}
-			
+
 			if (y + getHeight() > screenSize.height) {
 				y = screenSize.height - getHeight() - 10;
 			}
-			
+
 			if (x < 0) {
 				x = 0;
 			}
-			
+
 			if (y < 0) {
 				y = 0;
 			}
-			
+
 			setLocation(x, y);
 		}
-		
+
 		showHintPanelMenuItem.setSelected(Options.getInstance().isShowHintPanel());
 		showToolBarMenuItem.setSelected(Options.getInstance().isShowToolBar());
 
@@ -510,18 +510,18 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		levelMenuItems[2] = levelHardMenuItem;
 		levelMenuItems[3] = levelDiabolicalMenuItem;
 		levelMenuItems[4] = levelExtremeMenuItem;
-		
+
 		FontMetrics metrics = levelComboBox.getFontMetrics(levelComboBox.getFont());
 		int miWidth = 0;
 		int miHeight = metrics.getHeight();
 		Set<Character> mnemonics = new HashSet<Character>();
-		
+
 		for (int i = 1; i < DifficultyType.values().length; i++) {
-			
+
 			levelMenuItems[i - 1].setText(Options.getInstance().getDifficultyLevels()[i].getName());
 			char mnemonic = 0;
 			boolean mnemonicFound = false;
-			
+
 			for (int j = 0; j < Options.getInstance().getDifficultyLevels()[i].getName().length(); j++) {
 				mnemonic = Options.getInstance().getDifficultyLevels()[i].getName().charAt(j);
 				if (!mnemonics.contains(mnemonic)) {
@@ -529,12 +529,12 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					break;
 				}
 			}
-			
+
 			if (mnemonicFound) {
 				mnemonics.add(mnemonic);
 				levelMenuItems[i - 1].setMnemonic(mnemonic);
 			}
-			
+
 			levelComboBox.addItem(Options.getInstance().getDifficultyLevels()[i].getName());
 			int aktWidth = metrics.stringWidth(Options.getInstance().getDifficultyLevels()[i].getName());
 
@@ -542,7 +542,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				miWidth = aktWidth;
 			}
 		}
-		
+
 		mnemonics = null;
 
 		// mode menu items
@@ -572,19 +572,19 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		toggleButtons[7] = f8ToggleButton;
 		toggleButtons[8] = f9ToggleButton;
 		toggleButtons[9] = fxyToggleButton;
-		
+
 		for (int i = 0, lim = toggleButtons.length; i < lim; i++) {
-			
+
 			toggleButtonIconsOrg[i] = toggleButtons[i].getIcon();
 			toggleButtonIcons[i] = toggleButtons[i].getIcon();
-			
+
 			if (i < Sudoku2.UNITS) {
 				emptyToggleButtonIconsOrg[i] = new ImageIcon(getClass().getResource("/img/f_" + (i + 1) + "c_inactive.png"));
 			} else {
 				emptyToggleButtonIcons[i] = toggleButtons[i].getIcon();
 			}
 		}
-		
+
 		setToggleButton(null, false);
 		prepareToggleButtonIcons(Options.getInstance().isShowColorKu());
 
@@ -609,7 +609,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		if (launchFile != null && launchFile.endsWith("." + solutionFileExt)) {
 			loadFromFile(launchFile, 1);
 		}
-		
+
 		if (launchFile != null && launchFile.endsWith("." + textFileExt)) {
 			loadFromFile(launchFile, 8);
 		}
@@ -647,24 +647,24 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	public void updateCellSelectionStatus() {
-		
+
 		if (sudokuPanel == null) {
 			return;
 		}
-		
+
 		int size = sudokuPanel.getCellSelectionSize();
 		int r = sudokuPanel.getActiveRow() + 1;
 		int c = sudokuPanel.getActiveCol() + 1;
-		
+
 		if (size == 1) {
 			statusLabelCellSelection.setText("R"+r+"C"+c);
 		} else {
 			statusLabelCellSelection.setText("");
 		}
-		
+
 		statusLabelCellSelection.repaint();
 	}
-	
+
 	private void initComponents() {
 
 		levelButtonGroup = new javax.swing.ButtonGroup();
@@ -800,7 +800,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		reportErrorMenuItem = new javax.swing.JMenuItem();
 		askQuestionMenuItem = new javax.swing.JMenuItem();
 		aboutMenuItem = new javax.swing.JMenuItem();
-		
+
 		// Swing uses F10 as a default menu selector to navigate with keyboard.
 		// When setting filters, I accidently hit F10 all the time which stalls the key events.
 		// For this reason, I am disabling this feature and making F10 highlight bivalue cells instead.
@@ -811,13 +811,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			private static final long serialVersionUID = 628736937855343558L;
 			public void actionPerformed(ActionEvent e) {/*do nothing*/}
 		});
-		
+
 		setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
 		java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("intl/MainFrame");
 		setTitle(bundle.getString("MainFrame.title"));
 		setIconImage(getIcon());
 		addWindowListener(new java.awt.event.WindowAdapter() {
-			
+
 			@Override
 			public void windowClosed(java.awt.event.WindowEvent evt) {
 				formWindowClosed(evt);
@@ -997,7 +997,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		jSeparator25.setOrientation(javax.swing.SwingConstants.VERTICAL);
 		jSeparator25.setPreferredSize(new java.awt.Dimension(2, 17));
 		statusLinePanel.add(jSeparator25);
-		
+
 		statusLabelCellSelection.setText("");
 		statusLinePanel.add(statusLabelCellSelection);
 
@@ -1278,7 +1278,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			}
 		});
 		fileMenu.add(newMenuItem);
-		
+
 		newEmptyMenuItem.setText(bundle.getString("MainFrame.newEmptyMenuItem.text"));
 		newEmptyMenuItem.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -1400,7 +1400,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				extendedPrintMenuItemActionPerformed(evt);
 			}
 		});
-		fileMenu.add(extendedPrintMenuItem);			
+		fileMenu.add(extendedPrintMenuItem);
 
 		saveAsPictureMenuItem.setMnemonic(java.util.ResourceBundle.getBundle("intl/MainFrame")
 				.getString("MainFrame.speichernAlsBildMenuItemMnemonic").charAt(0));
@@ -1412,7 +1412,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		});
 		fileMenu.add(saveAsPictureMenuItem);
 		fileMenu.add(new javax.swing.JPopupMenu.Separator());
-		
+
 		quickBrowseMenuItem.setText("Quick Browse");
 		quickBrowseMenuItem.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -1543,7 +1543,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		});
 		editMenu.add(pasteMenuItem);
 		editMenu.add(new javax.swing.JPopupMenu.Separator());
-		
+
 		editGivensMenuItem.setMnemonic(java.util.ResourceBundle.getBundle("intl/MainFrame")
 				.getString("editGivensMenuItemMnemonic").charAt(0));
 		editGivensMenuItem.setText(bundle.getString("MainFrame.editGivensMenuItem.text"));
@@ -1827,10 +1827,10 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			}
 		});
 		puzzleMenu.add(solvePuzzleMenuItem);
-		
+
 		solutionCountMenuItem.setAccelerator(
 			javax.swing.KeyStroke.getKeyStroke(
-				java.awt.event.KeyEvent.VK_M, 
+				java.awt.event.KeyEvent.VK_M,
 				java.awt.event.InputEvent.CTRL_MASK
 			)
 		);
@@ -1840,7 +1840,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				showSolutionCount();
 			}
 		});
-		puzzleMenu.add(solutionCountMenuItem);		
+		puzzleMenu.add(solutionCountMenuItem);
 		puzzleMenu.add(new JSeparator());
 
 		backdoorSearchMenuItem.setMnemonic(java.util.ResourceBundle.getBundle("intl/MainFrame")
@@ -1883,14 +1883,14 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		});
 		puzzleMenu.add(restoreSavePointMenuItem);
 		puzzleMenu.add(new javax.swing.JPopupMenu.Separator());
-		
+
 		resetCandidatesMenuItem.setText(bundle.getString("MainFrame.resetCandidatesMenuItem.text"));
 		resetCandidatesMenuItem.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(java.awt.event.ActionEvent evt) {
 				resetCandidatesMenuItemActionPerformed(evt);
 			}
 		});
-		puzzleMenu.add(resetCandidatesMenuItem);		
+		puzzleMenu.add(resetCandidatesMenuItem);
 
 		setGivensMenuItem.setMnemonic(java.util.ResourceBundle.getBundle("intl/MainFrame")
 				.getString("MainFrame.setGivensMenuItem.mnemonic").charAt(0));
@@ -2149,14 +2149,14 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void configMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		new ConfigDialog(this, true, -1).setVisible(true);
 		sudokuPanel.resetActiveColor();
-		
+
 		if (cellZoomPanel.isColoring()) {
 			statusPanelColorResult.setBackground(sudokuPanel.getActiveColor());
 		}
-		
+
 		sudokuPanel.setColorIconsInPopupMenu();
 		check();
 		fixFocus();
@@ -2328,10 +2328,10 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			// in LEARNING ANY puzzle is accepted, that has at least one Training Step in it
 			actDiffLevel = Options.getInstance().getDifficultyLevel(DifficultyType.EXTREME.ordinal());
 		}
-		
+
 		String preGenSudoku = BackgroundGeneratorThread.getInstance().getSudoku(actDiffLevel, Options.getInstance().getGameMode());
 		Sudoku2 tmpSudoku = null;
-		
+
 		if (preGenSudoku == null) {
 			// no pre-genrated puzzle available -> do it in GUI
 			GenerateSudokuProgressDialog dlg = new GenerateSudokuProgressDialog(this, true, actDiffLevel, Options.getInstance().getGameMode());
@@ -2343,20 +2343,20 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			Sudoku2 solvedSudoku = tmpSudoku.clone();
 			SudokuSolver solver = SudokuSolverFactory.getDefaultSolverInstance();
 			solver.solve(
-				actDiffLevel, 
-				solvedSudoku, 
-				true, 
-				null, 
-				false, 
-				Options.getInstance().solverSteps, 
+				actDiffLevel,
+				solvedSudoku,
+				true,
+				null,
+				false,
+				Options.getInstance().solverSteps,
 				Options.getInstance().getGameMode()
 			);
 			tmpSudoku.setLevel(solvedSudoku.getLevel());
 			tmpSudoku.setScore(solvedSudoku.getScore());
 		}
-		
+
 		if (tmpSudoku != null) {
-			
+
 			sudokuPanel.setSudoku(tmpSudoku, true);
 			allStepsPanel.setSudoku(sudokuPanel.getSudoku());
 			initializeResultPanels();
@@ -2364,7 +2364,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			sudokuPanel.clearColoring();
 			sudokuPanel.setShowHintCellValue(0);
 			sudokuPanel.setShowInvalidOrPossibleCells(false);
-			
+
 			if (Options.getInstance().getGameMode() == GameMode.LEARNING) {
 				// solve the sudoku up until the first trainingStep
 				Sudoku2 trainingSudoku = sudokuPanel.getSudoku();
@@ -2377,13 +2377,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					}
 				}
 			}
-			
+
 			clearSavePoints();
 			sudokuFileName = null;
 			setTitleWithFile();
 			check();
 		}
-		
+
 		cellZoomPanel.setDefaultMouse(true);
 		sudokuPanel.clearColoring();
 		sudokuPanel.setActiveColor(null);
@@ -2442,18 +2442,18 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void alleHiddenSinglesSetzenMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		hinweisAbbrechenButtonActionPerformed(null);
 		SolutionStep step = null;
-		
+
 		while (
-			(step = sudokuPanel.getNextStep(true)) != null && 
-			(step.getType() == SolutionType.HIDDEN_SINGLE || 
-			 step.getType() == SolutionType.FULL_HOUSE || 
+			(step = sudokuPanel.getNextStep(true)) != null &&
+			(step.getType() == SolutionType.HIDDEN_SINGLE ||
+			 step.getType() == SolutionType.FULL_HOUSE ||
 			 step.getType() == SolutionType.NAKED_SINGLE)) {
 			sudokuPanel.doStep();
 		}
-		
+
 		sudokuPanel.abortStep();
 		sudokuPanel.checkProgress();
 		fixFocus();
@@ -2465,21 +2465,21 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void hinweisAusfuehrenButtonActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		sudokuPanel.doStep();
 		sudokuPanel.checkProgress();
 		hinweisTextArea.setText("");
 		hinweisAbbrechenButton.setEnabled(false);
 		hinweisAusfuehrenButton.setEnabled(false);
-		
+
 		if (executeStepToggleButton != null) {
 			executeStepToggleButton.setEnabled(false);
 		}
-		
+
 		if (abortStepToggleButton != null) {
 			abortStepToggleButton.setEnabled(false);
 		}
-		
+
 		fixFocus();
 	}
 
@@ -2516,9 +2516,9 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			// if no user candidates have been set, the internal flag is just toggled.
 			// if user candidates have been set, further checks have to be made
 			if (sudokuPanel.getSudoku().userCandidatesEmpty()) {
-				// just set the flag and be done!				
+				// just set the flag and be done!
 				sudokuPanel.setShowCandidates(showCandidatesMenuItem.isSelected());
-				
+
 			} else {
 				// display a dialog, that lets the user choose, what to do
 				boolean doYes = true;
@@ -2539,7 +2539,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						doYes = false;
 					}
 				}
-				
+
 				if (doYes) {
 					// retain all changes to the user candidates
 					sudokuPanel.getSudoku().resetCandidates();
@@ -2601,30 +2601,30 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void pasteMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		try {
-			
+
 			Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
 			Transferable clipboardContent = clip.getContents(this);
-			
+
 			if ((clipboardContent != null) && (clipboardContent.isDataFlavorSupported(DataFlavor.stringFlavor))) {
 				String content = (String) clipboardContent.getTransferData(DataFlavor.stringFlavor);
 				setPuzzle(content);
 				clearSavePoints();
 			}
-			
+
 		} catch (Exception ex) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Error pasting from clipboard", ex);
 		}
-		
+
 		check();
 		fixFocus();
 	}
 
 	private void outerSplitPanePropertyChange(java.beans.PropertyChangeEvent evt) {
-		
+
 		// if the hintPanel is to small, the horizontal divider is moved up
-		if (!outerSplitPaneInitialized && 
+		if (!outerSplitPaneInitialized &&
 			outerSplitPane.getSize().getHeight() != 0 &&
 			hintPanel.getSize().getHeight() != 0) {
 			// adjust to minimum size of hintPanel to allow for LAF differences
@@ -2667,11 +2667,11 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void solveUpToButtonActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		if (sudokuPanel != null) {
 			sudokuPanel.solveUpTo();
 		}
-		
+
 		check();
 		fixFocus();
 	}
@@ -2700,22 +2700,22 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void newEmptyGameMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		if (sudokuPanel.getSolvedCellsAnz() != 0) {
-			
+
 			int antwort = JOptionPane.showConfirmDialog(
 				this,
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.delete_sudoku"),
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.new_input"),
 				JOptionPane.YES_NO_OPTION
 			);
-			
+
 			// do nothing
 			if (antwort != JOptionPane.YES_OPTION) {
 				return;
 			}
 		}
-		
+
 		sudokuPanel.setSudoku((String) null);
 		sudokuPanel.checkProgress();
 		allStepsPanel.setSudoku(sudokuPanel.getSudoku());
@@ -2744,7 +2744,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			allStepsPanel.setSudoku(sudokuPanel.getSudoku());
 			initializeResultPanels();
 		}
-		
+
 		setPlay(true);
 	}
 
@@ -2755,12 +2755,12 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.reset_game"),
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.reset"),
 				JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
-			
+
 			sudokuPanel.setSudoku(sudokuPanel.getSudokuString(ClipboardMode.CLUES_ONLY));
 			sudokuPanel.checkProgress();
 			allStepsPanel.setSudoku(sudokuPanel.getSudoku());
 			allStepsPanel.resetPanel();
-			
+
 			repaint();
 			setPlay(true);
 			check();
@@ -2793,7 +2793,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void statusPanelColorResetMouseClicked(java.awt.event.MouseEvent evt) {
-		coloringPanelClicked(null);
+		coloringPanelReset();
 	}
 
 	private void colorCellsMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
@@ -2854,13 +2854,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void historyMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		GuiState state = new GuiState(sudokuPanel, sudokuPanel.getSolver(), solutionPanel);
 		state.get(true);
 		HistoryDialog dlg = new HistoryDialog(this, true);
 		dlg.setVisible(true);
 		String puzzle = dlg.getSelectedPuzzle();
-		
+
 		if (puzzle != null) {
 			if (dlg.isDoubleClicked()) {
 				// everything is already initialized, so don't do anything
@@ -2873,20 +2873,20 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			// restore everything
 			setState(state);
 		}
-		
+
 		state = null;
 	}
 
 	private void createSavePointMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
-		String defaultName = ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.createsp.default") + 
+
+		String defaultName = ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.createsp.default") +
 				" "	+ (savePoints.size() + 1);
-		
+
 		String name = (String) JOptionPane.showInputDialog(this,
 				ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.createsp.message"),
 				ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.createsp.title"),
 				JOptionPane.QUESTION_MESSAGE, null, null, defaultName);
-		
+
 		if (name != null) {
 			GuiState state = new GuiState(sudokuPanel, sudokuPanel.getSolver(), solutionPanel);
 			state.get(true);
@@ -2897,17 +2897,17 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void restoreSavePointMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		GuiState state = new GuiState(sudokuPanel, sudokuPanel.getSolver(), solutionPanel);
 		state.get(true);
 		RestoreSavePointDialog dlg = new RestoreSavePointDialog(this, true);
 		dlg.setVisible(true);
-		
+
 		if (!dlg.isOkPressed()) {
 			// restore everything
 			setState(state);
 		}
-		
+
 		state = null;
 	}
 
@@ -2929,17 +2929,17 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	private void backdoorSearchMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
 		new BackdoorSearchDialog(this, true, sudokuPanel).setVisible(true);
 	}
-	
+
 	private void resetCandidatesMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
 
 		java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("intl/MainFrame");
 		String msg = bundle.getString("MainFrame.resetCandidatesMenuItem.dialog");
-		
+
 		int input = JOptionPane.showConfirmDialog(null, msg);
 		if (input != 0) {
 			return;
 		}
-		
+
 		sudokuPanel.getSudoku().resetCandidates();
 		repaint();
 	}
@@ -2954,7 +2954,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void fullScreenMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		if (fullScreenMenuItem.isSelected()) {
 			changingFullScreenMode = true;
 			saveWindowStateInOptions();
@@ -2976,24 +2976,24 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			setWindowLayout(false);
 			setVisible(true);
 		}
-		
+
 		check();
 		fixFocus();
 	}
 
 	private void showHintPanelMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		Options.getInstance().setShowHintPanel(showHintPanelMenuItem.isSelected());
 		hintPanel.setVisible(showHintPanelMenuItem.isSelected());
-		
+
 		if (Options.getInstance().isShowHintPanel()) {
-			
+
 			int horzDivLoc = Options.getInstance().getInitialHorzDividerLoc();
 			if (horzDivLoc > getHeight() - 204) {
 				horzDivLoc = getHeight() - 204;
 				Options.getInstance().setInitialHorzDividerLoc(horzDivLoc);
 			}
-			
+
 			outerSplitPane.setDividerLocation(horzDivLoc);
 		}
 	}
@@ -3021,13 +3021,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void savePuzzleMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
-		
+
 		if (sudokuFileName != null) {
 			try {
 				saveToFile(true, sudokuFileName, sudokuFileType);
 			} catch (Exception ex) {
 				JOptionPane.showMessageDialog(
-					this, 
+					this,
 					ex.toString(),
 					java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.error"),
 					JOptionPane.ERROR_MESSAGE
@@ -3056,27 +3056,27 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * Adjusts icons for hint toggle buttons according to the mode (normal/ColorKu)
 	 * and according to the colors (necessary for color changes). Icons are created
 	 * on the fly as necessary.
-	 * 
+	 *
 	 * @param on
 	 */
 	private void prepareToggleButtonIcons(boolean on) {
-		
+
 		if (on) {
-			
+
 			for (int i = 0, lim = toggleButtons.length - 1; i < lim; i++) {
-				
-				if (toggleButtonImagesColorKu[i] == null || 
+
+				if (toggleButtonImagesColorKu[i] == null ||
 					!toggleButtonImagesColorKu[i].getColor().
 					equals(Options.getInstance().getColorKuColor(i + 1))) {
 
 					toggleButtonImagesColorKu[i] = new ColorKuImage(
-						TOGGLE_BUTTON_ICON_SIZE, 
+						TOGGLE_BUTTON_ICON_SIZE,
 						Options.getInstance().getColorKuColor(i + 1)
 					);
-					
+
 					toggleButtonIconsColorKu[i] = new ImageIcon(toggleButtonImagesColorKu[i]);
 				}
-				
+
 				toggleButtonIcons[i] = toggleButtonIconsColorKu[i];
 				emptyToggleButtonIcons[i] = emptyToggleButtonIconOrgColorKu;
 			}
@@ -3092,82 +3092,82 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	/**
 	 * Gets a new hint for the sudoku if possible. Checks are made to ensure, that
 	 * hints are only displayed for valid puzzles.
-	 * 
+	 *
 	 * @param mode <code>0</code> for "vage hint", <code>1</code> for "concrete
 	 *             hint" and <code>2</code> for "show next step".
 	 */
 	private void getHint(int mode) {
-		
+
 		if (sudokuPanel.getSudoku().isSolved()) {
-			
+
 			JOptionPane.showMessageDialog(
 				this,
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.already_solved")
 			);
-			
+
 			return;
 		}
-		
-		if (sudokuPanel.getSudoku().getStatus() == SudokuStatus.EMPTY || 
+
+		if (sudokuPanel.getSudoku().getStatus() == SudokuStatus.EMPTY ||
 			sudokuPanel.getSudoku().getStatus() == SudokuStatus.INVALID) {
-			
+
 			JOptionPane.showMessageDialog(
 				this,
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.invalid_puzzle")
 			);
-			
+
 			return;
 		}
-		
+
 		if (!sudokuPanel.isShowCandidates()) {
-			
+
 			JOptionPane.showMessageDialog(
 				this,
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.not_available"),
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.hint"),
 				JOptionPane.INFORMATION_MESSAGE
 			);
-			
+
 			return;
 		}
-		
+
 		if (sudokuPanel.getSudoku().checkSudoku() == false) {
-			
+
 			JOptionPane.showMessageDialog(
 				this,
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.invalid_values_or_candidates"),
 				java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.hint"),
 				JOptionPane.INFORMATION_MESSAGE
 			);
-			
+
 			return;
 		}
-		
+
 		SolutionStep step = sudokuPanel.getNextStep(false);
 		if (mode == 0 || mode == 1) {
-			
+
 			sudokuPanel.abortStep();
 			fixFocus();
-			
+
 			if (step != null) {
-				
+
 				int strMode = 0;
 				String msg = java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.vage_hint");
-				
+
 				if (mode == 1) {
 					strMode = 1;
 					msg = java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.medium_hint");
 				}
-				
+
 				JOptionPane.showMessageDialog(
 					this,
 					java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.possible_step") + step.toString(strMode),
 					msg,
 					JOptionPane.INFORMATION_MESSAGE
 				);
-				
+
 			} else {
-				
+
 				JOptionPane.showMessageDialog(
 					this,
 					java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.dont_know"),
@@ -3176,7 +3176,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				);
 			}
 		} else {
-			
+
 			if (step != null) {
 				setSolutionStep(step, false);
 			} else {
@@ -3184,7 +3184,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				hinweisTextArea.setCaretPosition(0);
 			}
 		}
-		
+
 		fixFocus();
 		check();
 	}
@@ -3197,16 +3197,16 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * If a user tries to set "learning" or "practising", but doesnt select any
 	 * steps, "playing" is set.<br>
 	 * If the configuration dialog is cancelled, the mode is not changed.
-	 * 
+	 *
 	 * @param newMode
 	 * @param showDialog
 	 */
 	private void setMode(GameMode newMode, boolean showDialog) {
-		
+
 		if (newMode == GameMode.PLAYING) {
 			Options.getInstance().setGameMode(newMode);
 		} else {
-			
+
 			if (showDialog) {
 				// show config dialog
 				ConfigTrainingDialog dlg = new ConfigTrainingDialog(this, true);
@@ -3215,19 +3215,19 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					return;
 				}
 			}
-			
+
 			String techniques = Options.getInstance().getTrainingStepsString(true);
 			if (techniques.isEmpty()) {
-				
+
 				JOptionPane.showMessageDialog(
 					this,
 					ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.notechniques"),
 					ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.error"),
 					JOptionPane.ERROR_MESSAGE
 				);
-				
+
 				Options.getInstance().setGameMode(GameMode.PLAYING);
-				
+
 			} else {
 				Options.getInstance().setGameMode(newMode);
 			}
@@ -3240,7 +3240,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * {@link #historyMenuItemActionPerformed(java.awt.event.ActionEvent)}. This
 	 * method should only be used if the puzzle is only available as String. If more
 	 * state information is saved, use {@link #setState(sudoku.GuiState)} instead.
-	 * 
+	 *
 	 * @param puzzle
 	 */
 	public void setPuzzle(String puzzle) {
@@ -3265,7 +3265,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * Restores a complete GUI state including puzzle (optionally with coloring and
 	 * selected step), solutions and summary. Used by {@link #loadFromFile(boolean)}
 	 * and {@link RestoreSavePointDialog}.<br>
-	 * 
+	 *
 	 * @param state
 	 */
 	public void setState(GuiState state) {
@@ -3284,7 +3284,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * adjusted accordingly. New sudokus are always inserted at the start of the
 	 * list and deleted from the end of the list, effectively turning the list in a
 	 * queue (the performance overhead can be ignored here).
-	 * 
+	 *
 	 * @param sudoku
 	 */
 	private void addSudokuToHistory(Sudoku2 sudoku) {
@@ -3297,55 +3297,66 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * clearing the list.
 	 */
 	private void clearSavePoints() {
-		
+
 		for (int i = 0; i < savePoints.size(); i++) {
 			savePoints.set(i, null);
 		}
-		
+
 		savePoints.clear();
 	}
 
 	/**
 	 * Should be called only from {@link CellZoomPanel}.
-	 * 
+	 *
 	 * @param colorNumber
 	 * @param isCell
 	 */
 	public void setColoring(Color color, boolean isCell) {
-		
+
 		//sudokuPanel.setColorCells(isCell);
 		if (isCell) {
 			cellZoomPanel.setColorCells(true);
 		} else {
 			cellZoomPanel.setColorCandidates(true);
 		}
-		
+
 		coloringPanelClicked(color);
 		check();
 		fixFocus();
 	}
 
+	public void coloringPanelReset() {
+		sudokuPanel.resetColoring();
+		check();
+		fixFocus();
+	}
+
 	public void coloringPanelClicked(Color color) {
-		
+
 		if (color == null) {
-			
+
 			statusPanelColorResult.setBackground(Options.getInstance().getDefaultCellColor());
 			sudokuPanel.setActiveColor(null);
+			cellZoomPanel.resetColoring();
 			/*
 			if (colorNumber == -2) {
 				sudokuPanel.clearColoring();
 				repaint();
 			}*/
-			
+
 		} else {
-			
+			if (!cellZoomPanel.isColoring()) {
+				cellZoomPanel.setColorCandidates(true);
+			}
+			cellZoomPanel.setPrimaryColor(color);
+
 			statusPanelColorResult.setBackground(color);
 			sudokuPanel.setActiveColor(color);
 		}
 	}
 
 	private void tabPaneMouseClicked(java.awt.event.MouseEvent evt) {
-		
+
 		if (evt.getButton() == MouseEvent.BUTTON1) {
 			switch (tabPane.getSelectedIndex()) {
 			case 0:
@@ -3365,37 +3376,37 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void saveWindowStateInOptions() {
-		
+
 		// save the complete window state
 		Options o = Options.getInstance();
 		o.setInitialXPos(getX());
 		o.setInitialYPos(getY());
 		o.setInitialHeight(getHeight());
 		o.setInitialWidth(getWidth());
-		
+
 		// the horizontal divider position must not be saved if the panel is not visible!
 		if (o.isShowHintPanel()) {
 			o.setInitialHorzDividerLoc(outerSplitPane.getDividerLocation());
 		}
-		
+
 		// sudoku only
 		o.setInitialDisplayMode(0);
 		if (summaryMenuItem.isSelected()) {
 			o.setInitialDisplayMode(1);
 		}
-		
+
 		if (solutionMenuItem.isSelected()) {
 			o.setInitialDisplayMode(2);
 		}
-		
+
 		if (allStepsMenuItem.isSelected()) {
 			o.setInitialDisplayMode(3);
 		}
-		
+
 		if (cellZoomMenuItem.isSelected()) {
 			o.setInitialDisplayMode(4);
 		}
-		
+
 		o.setInitialVertDividerLoc(-1);
 		if (o.getInitialDisplayMode() != 0) {
 			splitPanel.getDividerLocation();
@@ -3403,7 +3414,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void writeOptionsWithWindowState(String fileName) throws FileNotFoundException {
-		
+
 		// save window state
 		saveWindowStateInOptions();
 		if (fileName == null) {
@@ -3414,7 +3425,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void setWindowLayout(boolean reset) {
-		
+
 		Options o = Options.getInstance();
 
 		if (reset) {
@@ -3440,17 +3451,17 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		if (screenSize.height - 45 < height) {
 			height = screenSize.height - 45;
 		}
-		
+
 		if (horzDivLoc > height - 204) {
 			horzDivLoc = height - 204;
 			// can be used during program run, so has to be saved here
 			Options.getInstance().setInitialHorzDividerLoc(horzDivLoc);
 		}
-		
+
 		if (screenSize.width - 20 < width) {
 			width = screenSize.width - 20;
 		}
-		
+
 		setSize(width, height);
 		switch (o.getInitialDisplayMode()) {
 		case 0:
@@ -3502,18 +3513,18 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void setSplitPane(JPanel panel) {
-		
+
 		if (!splitPanel.hasRight()) {
 			splitPanel.setRight(tabPane);
 		}
-		
+
 		tabPane.setSelectedComponent(panel);
 	}
 
 	private void setPlay(boolean isPlaying) {
-		
+
 		gameMode = !isPlaying;
-		
+
 		if (isPlaying) {
 			if (oldShowDeviationsValid) {
 				showDeviationsMenuItem.setSelected(oldShowDeviations);
@@ -3524,7 +3535,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			oldShowDeviationsValid = true;
 			showDeviationsMenuItem.setSelected(false);
 		}
-		
+
 		showDeviationsMenuItemActionPerformed(null);
 
 		vagueHintMenuItem.setEnabled(isPlaying);
@@ -3539,7 +3550,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	public void setSolutionStep(SolutionStep step, boolean setInSudokuPanel) {
-		
+
 		if (setInSudokuPanel) {
 			if (step == null) {
 				sudokuPanel.abortStep();
@@ -3547,38 +3558,38 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				sudokuPanel.setStep(step);
 			}
 		}
-		
+
 		if (step == null) {
-			
+
 			hinweisTextArea.setText("");
 			hinweisAbbrechenButton.setEnabled(false);
 			hinweisAusfuehrenButton.setEnabled(false);
-			
+
 			if (executeStepToggleButton != null) {
 				executeStepToggleButton.setEnabled(false);
 			}
-			
+
 			if (abortStepToggleButton != null) {
 				abortStepToggleButton.setEnabled(false);
 			}
-			
+
 		} else {
-			
+
 			hinweisTextArea.setText(step.toString());
 			hinweisTextArea.setCaretPosition(0);
 			hinweisAbbrechenButton.setEnabled(true);
 			hinweisAusfuehrenButton.setEnabled(true);
 			getRootPane().setDefaultButton(hinweisAusfuehrenButton);
-			
+
 			if (executeStepToggleButton != null) {
 				executeStepToggleButton.setEnabled(true);
 			}
-			
+
 			if (abortStepToggleButton != null) {
 				abortStepToggleButton.setEnabled(true);
 			}
 		}
-		
+
 		fixFocus();
 	}
 
@@ -3586,14 +3597,14 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * Copy the current sudoku to the clipboard. If <code>simpleSudoku</code> is set
 	 * to <code>true</code>, the givensm the currently set cells and a PM grid are
 	 * copied.
-	 * 
+	 *
 	 * @param mode
 	 * @param simpleSudoku
 	 */
 	private void copyToClipboard(ClipboardMode mode, boolean simpleSudoku) {
-		
+
 		String clipStr = "";
-		
+
 		if (simpleSudoku) {
 			String dummy = sudokuPanel.getSudokuString(ClipboardMode.CLUES_ONLY);
 			clipStr = SudokuUtil.getSSFormatted(dummy);
@@ -3608,7 +3619,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		} else {
 			clipStr = sudokuPanel.getSudokuString(mode);
 		}
-		
+
 		try {
 			Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
 			StringSelection content = new StringSelection(clipStr);
@@ -3616,23 +3627,23 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		} catch (Exception ex) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Error writing to clipboard", ex);
 		}
-		
+
 		fixFocus();
 	}
 
 	private void setToggleButton(JToggleButton button, boolean ctrlPressed) {
-		
+
 		if (button == null) {
 			sudokuPanel.resetShowHintCellValues();
 		} else {
-			
+
 			int index = 0;
 			for (index = 0; index < toggleButtons.length; index++) {
 				if (toggleButtons[index] == button) {
 					break;
 				}
 			}
-			
+
 			if (index == Sudoku2.UNITS) {
 				sudokuPanel.setShowHintCellValue(index + 1);
 			} else {
@@ -3650,7 +3661,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			}
 			sudokuPanel.checkIsShowInvalidOrPossibleCells();
 		}
-		
+
 		check();
 		sudokuPanel.repaint();
 		fixFocus();
@@ -3658,22 +3669,22 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 	/**
 	 * Save puzzles/configurations.
-	 * 
+	 *
 	 * @param puzzle
 	 */
 	private void saveToFile(boolean puzzle) {
-		
+
 		JFileChooser chooser = new JFileChooser(Options.getInstance().getDefaultFileDir());
 		chooser.setAcceptAllFileFilterUsed(false);
 		MyFileFilter[] filters = puzzleFileSaveFilters;
 		if (!puzzle) {
 			filters = configFileFilters;
 		}
-		
+
 		for (int i = 0; i < filters.length; i++) {
 			chooser.addChoosableFileFilter(filters[i]);
 		}
-		
+
 		int returnVal = chooser.showSaveDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			try {
@@ -3703,7 +3714,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						}
 					}
 				}
-				
+
 				File checkFile = new File(path);
 				if (checkFile.exists()) {
 					// Override warning!
@@ -3720,19 +3731,19 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				}
 
 				saveToFile(puzzle, path, filterType);
-				
+
 			} catch (Exception ex2) {
-				
+
 				JOptionPane.showMessageDialog(
-					this, 
+					this,
 					ex2.toString(),
 					java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.error"),
 					JOptionPane.ERROR_MESSAGE
 				);
-				
+
 				sudokuFileName = null;
 			}
-			
+
 			setTitleWithFile();
 		}
 	}
@@ -3743,7 +3754,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * one of the file types defined by {@link MyFileFilter}. If the method is
 	 * called via the "Save puzzle" menu item, <code>filterType</code> can be 8
 	 * (generic text file). In this case a PM grid is written.
-	 * 
+	 *
 	 * @param puzzle
 	 * @param path
 	 * @param filterType
@@ -3751,9 +3762,9 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 * @throws IOException
 	 */
 	private void saveToFile(boolean puzzle, String path, int filterType) throws FileNotFoundException, IOException {
-		
+
 		sudokuFileName = path;
-		
+
 		if (!puzzle) {
 			// Options
 			writeOptionsWithWindowState(path);
@@ -3761,7 +3772,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 			String newLine = System.getProperty("line.separator");
 			if (filterType == 1) {
-				
+
 				sudokuFileType = 1;
 				ZipOutputStream zOut = new ZipOutputStream(new FileOutputStream(path));
 				zOut.putNextEntry(new ZipEntry("SudokuData"));
@@ -3775,9 +3786,9 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				out.close();
 				zOut.flush();
 				zOut.close();
-				
+
 			} else if (filterType == 9) {
-				
+
 				sudokuFileType = 9;
 				// SimpleSudoku format (see comment in loadFromFile())
 				PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(path)));
@@ -3791,7 +3802,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						out.printf("I%02d%d%n", i, tmpSudoku.getValue(i));
 					}
 				}
-				
+
 				// eliminated candidates
 				for (int i = 0; i < Sudoku2.LENGTH; i++) {
 					if (tmpSudoku.getValue(i) == 0) {
@@ -3802,17 +3813,17 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						}
 					}
 				}
-				
+
 				out.close();
-				
+
 			} else {
-				
+
 				sudokuFileType = 8;
 				if (filterType == 8) {
 					// generic text file: can occur when save is executed
 					filterType = 6;
 				}
-				
+
 				BufferedWriter out = new BufferedWriter(new FileWriter(path));
 				String line = "";
 				switch (filterType) {
@@ -3841,7 +3852,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					line = sudokuPanel.getSudokuString(ClipboardMode.LIBRARY);
 					break;
 				}
-				
+
 				out.write(line);
 				out.close();
 			}
@@ -3851,23 +3862,23 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	/**
 	 * Loads puzzles and/or configurations from files. loading either type resets
 	 * the mode to "playing".
-	 * 
+	 *
 	 * @param puzzle
 	 */
 	private void loadFromFile(boolean puzzle) {
-		
+
 		JFileChooser chooser = new JFileChooser(Options.getInstance().getDefaultFileDir());
 		chooser.setAcceptAllFileFilterUsed(false);
 		MyFileFilter[] filters = puzzleFileLoadFilters;
-		
+
 		if (!puzzle) {
 			filters = configFileFilters;
 		}
-		
+
 		for (int i = 0; i < filters.length; i++) {
 			chooser.addChoosableFileFilter(filters[i]);
 		}
-		
+
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			String path = chooser.getSelectedFile().getPath();
@@ -3885,7 +3896,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 	/**
 	 * Verify if the import line contains valid characters.
-	 * 
+	 *
 	 * @param importString
 	 * @return
 	 */
@@ -3896,18 +3907,18 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 		String error1 = bundle.getString("MainFrame.ValidateImportLine.error1");
 		String error2a = bundle.getString("MainFrame.ValidateImportLine.error2a");
 		String error2b = bundle.getString("MainFrame.ValidateImportLine.error2b");
-		
+
 		if (line.length() != Sudoku2.LENGTH) {
 			ShowWarningMSG(title, error1);
 			return false;
 		}
 
 		for (int i = 0; i < line.length(); i++) {
-			
+
 			char c = line.charAt(i);
 			boolean isDigit = c >= '0' && c <= '9';
 			boolean isEmpty = c == '.';
-			
+
 			if (!isDigit && !isEmpty) {
 				ShowWarningMSG(title, error2a + c + error2b);
 				return false;
@@ -3933,13 +3944,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 		boolean isStatusValid = sudokuPanel.getSudoku().getStatus() == SudokuStatus.VALID;
 		boolean hasMultipleSolutions = sudokuPanel.getSudoku().getStatus() == SudokuStatus.MULTIPLE_SOLUTIONS;
-		
-		if (hasMultipleSolutions) {			
+
+		if (hasMultipleSolutions) {
 			String msg = java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.solve_error");
-			JOptionPane.showMessageDialog(this, msg);			
+			JOptionPane.showMessageDialog(this, msg);
 			return;
 		}
-		
+
 		if (!isStatusValid || sudokuPanel.getSudoku().isSolved()) {
 			return;
 		}
@@ -3956,20 +3967,20 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 		repaint();
 	}
-	
+
 	public void showSolutionCount() {
-		
+
 		ResourceBundle bundle = java.util.ResourceBundle.getBundle("intl/MainFrame");
 		String msg1 = bundle.getString("MainFrame.solutionCountMenuItem.msg1");
 		String msg2 = bundle.getString("MainFrame.solutionCountMenuItem.msg2");
 		String msg3 = bundle.getString("MainFrame.solutionCountMenuItem.msg3");
 		String msg4 = bundle.getString("MainFrame.solutionCountMenuItem.msg4");
 		String msg5 = bundle.getString("MainFrame.solutionCountMenuItem.msg5");
-		
+
 		Sudoku2 sudoku = sudokuPanel.getSudoku().clone();
 		SudokuGenerator generator = SudokuGeneratorFactory.getDefaultGeneratorInstance();
 		int solutionCount = generator.getNumberOfSolutions(sudoku, 999);
-		
+
 		if (solutionCount == 0) {
 			JOptionPane.showMessageDialog(
 				this,
@@ -3995,7 +4006,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 	/**
 	 * Loads a file
-	 * 
+	 *
 	 * @param path
 	 * @param fileType 0 .. options, 1 .. sudoku from hsol, 8 .. sudoku from text
 	 *                 file
@@ -4034,13 +4045,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					// that is not needed anymore
 					sudokuTemp = in.readObject();
 				}
-				
+
 				state.setAnzSteps((int[]) in.readObject());
 				state.setSteps((List<SolutionStep>) in.readObject());
 				state.setTitels((List<String>) in.readObject());
 				state.setTabSteps((List<List<SolutionStep>>) in.readObject());
 				state.resetAnzSteps();
-				
+
 				try {
 					savePoints = (List<GuiState>) in.readObject();
 					for (int i = 0; i < savePoints.size(); i++) {
@@ -4053,29 +4064,29 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					// format is incompatible
 					clearSavePoints();
 				}
-				
+
 				in.close();
 				setState(state);
 				setMode(GameMode.PLAYING, true);
-				
+
 			} else if (fileType == 8) {
-				
+
 				// load from text file
 				BufferedReader in = new BufferedReader(new FileReader(path));
 				StringBuilder tmp = new StringBuilder();
 				String line = null;
-				
+
 				while ((line = in.readLine()) != null) {
 					tmp.append(line);
 					tmp.append("\r\n");
 				}
-				
+
 				in.close();
 				setPuzzle(tmp.toString());
 				clearSavePoints();
-				
+
 			} else if (fileType == 9) {
-				
+
 				// SimpleSudoku format: The givens followed by set cells and eliminated
 				// candidates
 				// example:
@@ -4107,29 +4118,29 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				BufferedReader in = new BufferedReader(new FileReader(path));
 				StringBuilder tmp = new StringBuilder();
 				String line = null;
-				
+
 				while ((line = in.readLine()) != null) {
-					
+
 					if (line.trim().isEmpty()) {
 						// all the givens are read -> abort reading
 						break;
 					}
-					
+
 					tmp.append(line);
 					tmp.append("\r\n");
 				}
-				
+
 				// first set the givens
 				Sudoku2 tmpSudoku = new Sudoku2();
 				tmpSudoku.setSudoku(tmp.toString());
-				
+
 				// now read set cells and eliminations
 				while ((line = in.readLine()) != null) {
-					
+
 					if (line.trim().isEmpty()) {
 						continue;
 					}
-					
+
 					char recordType = line.charAt(0);
 					if (recordType == 'I') {
 						int index = Integer.parseInt(line.substring(1, 3));
@@ -4141,14 +4152,14 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						tmpSudoku.delCandidate(index, candidate);
 					}
 				}
-				
+
 				in.close();
 				// everything read and decoded -> set the sudoku
 				setPuzzle(tmpSudoku.getSudoku(ClipboardMode.LIBRARY));
 				clearSavePoints();
-				
+
 			} else {
-				
+
 				formatter.applyPattern(java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.invalid_filename"));
 				String msg = formatter.format(new Object[] { path });
 				JOptionPane.showMessageDialog(
@@ -4157,7 +4168,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					java.util.ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.error"),
 					JOptionPane.ERROR_MESSAGE
 				);
-				
+
 				sudokuFileName = null;
 			}
 		} catch (Exception ex2) {
@@ -4170,7 +4181,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			ex2.printStackTrace();
 			sudokuFileName = null;
 		}
-		
+
 		setTitleWithFile();
 	}
 
@@ -4179,13 +4190,13 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	 */
 	/*
 	public static void main(String args[]) {
-		
+
 		try {
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 		} catch (Exception ex) {
 			Logger.getLogger(MainFrame.class.getName()).log(Level.SEVERE, "Error setting LaF", ex);
 		}
-		
+
 		java.awt.EventQueue.invokeLater(new Runnable() {
 			@Override
 			public void run() {
@@ -4195,7 +4206,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}*/
 
 	private void setTitleWithFile() {
-		
+
 		savePuzzleMenuItem.setEnabled(sudokuFileName != null);
 		if (sudokuFileName == null) {
 			setTitle(VERSION);
@@ -4211,7 +4222,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	private void setLevelFromMenu() {
-		
+
 		int selected = 0;
 		for (int i = 0; i < levelMenuItems.length; i++) {
 			if (levelMenuItems[i].isSelected()) {
@@ -4243,9 +4254,9 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	public final void check() {
-		
+
 		if (sudokuPanel != null) {
-			
+
 			undoMenuItem.setEnabled(sudokuPanel.undoPossible());
 			undoToolButton.setEnabled(sudokuPanel.undoPossible());
 			redoMenuItem.setEnabled(sudokuPanel.redoPossible());
@@ -4255,15 +4266,15 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			showDeviationsMenuItem.setSelected(sudokuPanel.isShowDeviations());
 			showColorKuMenuItem.setSelected(Options.getInstance().isShowColorKuAct());
 			prepareToggleButtonIcons(Options.getInstance().isShowColorKuAct());
-			
+
 			// either all ToggleButtons are set or none is
 			if (toggleButtons[0] != null) {
-				
+
 				boolean[] remainingCandidates = sudokuPanel.getRemainingCandidates();
 				for (int i = 0; i < remainingCandidates.length; i++) {
-					
+
 					JToggleButton button = toggleButtons[i];
-					
+
 					// change the standard icons
 					if (remainingCandidates[i]) {
 
@@ -4278,7 +4289,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						}
 					}
 				}
-				
+
 				for (int i = 0; i < toggleButtons.length; i++) {
 					if (toggleButtons[i].isEnabled()) {
 						if (sudokuPanel.getShowHintCellValues()[i + 1]) {
@@ -4289,25 +4300,25 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					}
 				}
 			}
-			
+
 			redGreenToggleButton.setSelected(sudokuPanel.isInvalidCells());
 			Sudoku2 sudoku = sudokuPanel.getSudoku();
 			if (sudoku != null) {
-				
+
 				DifficultyLevel tmpLevel = sudoku.getLevel();
 				if (tmpLevel != null) {
 					statusLabelLevel.setText(StepConfig.getLevelName(tmpLevel) + " (" + sudoku.getScore() + ")");
 				} else {
 					statusLabelLevel.setText("-");
 				}
-				
+
 				setProgressLabel();
-				
+
 			} else {
 				// no puzzle loaded
 				statusLabelLevel.setText(ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.statusLabelLevel.text"));
 			}
-			
+
 			if (cellZoomPanel.isColoringCells()) {
 				colorCellsMenuItem.setSelected(true);
 				statusLabelCellCandidate.setText(ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.statusLabelCellCandidate.text.cell"));
@@ -4317,10 +4328,10 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			} else if (cellZoomPanel.isDefaultMouse()) {
 				statusLabelCellCandidate.setText(ResourceBundle.getBundle("intl/MainFrame").getString("MainFrame.statusLabelCellCandidate.text.default"));
 			}
-			
+
 			fixFocus();
 		}
-		
+
 		// adjust mode menus and labels
 		// Options.actLevel is always valid
 		if (Options.getInstance().getActLevel() != -1) {
@@ -4334,57 +4345,57 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 						tmpLevel = act.getLevel();
 					}
 				}
-				
+
 				if (tmpLevel != Options.getInstance().getActLevel()) {
 //                    level = Options.getInstance().getDifficultyLevel(tmpLevel);
 					Options.getInstance().setActLevel(tmpLevel);
 				}
 			}
-			
+
 			int ord = Options.getInstance().getActLevel() - 1;
 			if (levelMenuItems[ord] != null && levelComboBox.getItemCount() > ord) {
 				levelMenuItems[ord].setSelected(true);
 				levelComboBox.setSelectedIndex(ord);
 			}
-			
+
 			int mOrdinal = Options.getInstance().getGameMode().ordinal();
 			if (modeMenuItems != null && modeMenuItems[mOrdinal] != null) {
-				
+
 				modeMenuItems[mOrdinal].setSelected(true);
-				
+
 				String labelStr = modeMenuItems[mOrdinal].getText();
 				if (labelStr.endsWith("...")) {
 					labelStr = labelStr.substring(0, labelStr.length() - 3);
 				}
-				
+
 				if (Options.getInstance().getGameMode() != GameMode.PLAYING) {
 					labelStr += " (" + Options.getInstance().getTrainingStepsString(true) + ")";
 				}
-				
+
 				statusLabelModus.setText(labelStr);
 			}
-			
+
 			showHintButtonsCheckBoxMenuItem.setSelected(Options.getInstance().isShowHintButtonsInToolbar());
 		}
-		
+
 		statusLinePanel.invalidate();
 	}
 
 	private boolean isStringFlavorInClipboard() {
-		
+
 		Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
 
 		if (clip.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
 			return true;
 		}
-		
+
 		return false;
 	}
 
 	private void adjustPasteMenuItem() {
-		
+
 		try {
-			
+
 			if (Main.OS_NAME.contains("mac")) {
 				pasteMenuItem.setEnabled(true);
 			} else {
@@ -4394,7 +4405,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					pasteMenuItem.setEnabled(false);
 				}
 			}
-			
+
 		} catch (IllegalStateException ex) {
 			clipTimer.start();
 		}
@@ -4415,30 +4426,30 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	}
 
 	public void abortStep() {
-		
+
 		sudokuPanel.abortStep();
 		hinweisTextArea.setText("");
 		hinweisAbbrechenButton.setEnabled(false);
 		hinweisAusfuehrenButton.setEnabled(false);
-		
+
 		if (executeStepToggleButton != null) {
 			executeStepToggleButton.setEnabled(false);
 		}
-		
+
 		if (abortStepToggleButton != null) {
 			abortStepToggleButton.setEnabled(false);
 		}
-		
+
 		fixFocus();
 	}
 
 	private void createProgressLabelImages() {
-		
+
 		try {
-			
+
 			progressImages[0] = new ImageIcon(getClass().getResource("/img/invalid20.png"));
 			BufferedImage overlayImage = ImageIO.read(getClass().getResource("/img/ce1-20.png"));
-			
+
 			for (int i = 1; i < progressImages.length; i++) {
 				BufferedImage act = new BufferedImage(20, 20, BufferedImage.TYPE_4BYTE_ABGR);
 				Graphics2D gAct = (Graphics2D) act.getGraphics();
@@ -4448,46 +4459,46 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 				gAct.drawImage(overlayImage, 0, 0, null);
 				progressImages[i] = new ImageIcon(act);
 			}
-			
+
 		} catch (Exception ex) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Error creating progressLabel images", ex);
 		}
 	}
 
 	public void setProgressLabel() {
-		
+
 		if (sudokuPanel == null) {
 			// do nothing
 			return;
 		}
-		
+
 		Sudoku2 sudoku = sudokuPanel.getSudoku();
 		if (sudoku.getStatus() != SudokuStatus.VALID) {
 			progressLabel.setIcon(progressImages[0]);
 			progressLabel.setText("-");
 			return;
 		}
-		
+
 		// ok valid sudoku, currentLevel and currentScore must have been set
 		// not necessarily!
 		if (getCurrentLevel() != null) {
-			
+
 			progressLabel.setIcon(progressImages[getCurrentLevel().getOrdinal()]);
 			double proc = getCurrentScore();
 			int intProc = (int) (proc / sudoku.getScore() * 100);
-			
+
 			if (intProc > 100) {
 				intProc = 100;
 			}
-			
+
 			if (intProc < 1) {
 				intProc = 1;
 			}
-			
+
 			if (getCurrentScore() == 0) {
 				intProc = 0;
 			}
-			
+
 			progressLabel.setText(intProc + "%");
 		}
 	}
@@ -4523,12 +4534,12 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 	/**
 	 * Handles the display of the hint buttons in the toolbar. If they are made
 	 * visible the first time, they have to be created.
-	 * 
+	 *
 	 */
 	private void setShowHintButtonsInToolbar() {
-		
+
 		if (vageHintToggleButton == null) {
-			
+
 			// create the buttons
 			hintSeperator = new javax.swing.JSeparator();
 			hintSeperator.setOrientation(javax.swing.SwingConstants.VERTICAL);
@@ -4603,7 +4614,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			jToolBar1.add(abortStepToggleButton);
 		}
 		if (Options.getInstance().isShowHintButtonsInToolbar()) {
-			
+
 			hintSeperator.setVisible(true);
 			vageHintToggleButton.setVisible(true);
 			concreteHintToggleButton.setVisible(true);
@@ -4612,9 +4623,9 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			abortStepToggleButton.setVisible(true);
 			executeStepToggleButton.setEnabled(hinweisAusfuehrenButton.isEnabled());
 			abortStepToggleButton.setEnabled(hinweisAusfuehrenButton.isEnabled());
-			
+
 		} else {
-			
+
 			hintSeperator.setVisible(false);
 			vageHintToggleButton.setVisible(false);
 			concreteHintToggleButton.setVisible(false);
@@ -4622,14 +4633,14 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			executeStepToggleButton.setVisible(false);
 			abortStepToggleButton.setVisible(false);
 		}
-		
+
 		check();
 		fixFocus();
 	}
 
 	/**
 	 * Action event for hint buttons
-	 * 
+	 *
 	 * @param isVage
 	 */
 	private void hintToggleButtonActionPerformed(boolean isVage) {
@@ -4654,11 +4665,11 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 		@Override
 		public boolean accept(File f) {
-			
+
 			if (f.isDirectory()) {
 				return true;
 			}
-			
+
 			String[] parts = f.getName().split("\\.");
 			if (parts.length > 1) {
 				String ext = parts[parts.length - 1];
@@ -4751,7 +4762,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 
 		@Override
 		public void caretUpdate(CaretEvent e) {
-			
+
 			if (inUpdate) {
 				// no recursion!
 				return;
@@ -4771,11 +4782,11 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 			int start = 0;
 			int end = 0;
 			int act = -1;
-			
+
 			while (act < dot) {
-				
+
 				act = text.indexOf('\n', act + 1);
-				
+
 				if (act == -1) {
 					// ok, done
 					end = text.length() - 1;
@@ -4788,11 +4799,11 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					break;
 				}
 			}
-			
+
 			if (end > 0) {
-				
+
 				inUpdate = true;
-				
+
 				if (line == 0) {
 					sudokuPanel.setChainInStep(-1);
 				} else {
@@ -4800,7 +4811,7 @@ public class MainFrame extends javax.swing.JFrame implements FlavorListener {
 					hinweisTextArea.setSelectionEnd(end);
 					sudokuPanel.setChainInStep(line - 1);
 				}
-				
+
 				inUpdate = false;
 			}
 		}

--- a/src/sudoku/SudokuPanel.java
+++ b/src/sudoku/SudokuPanel.java
@@ -110,7 +110,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		KeyEvent.VK_6, KeyEvent.VK_7, KeyEvent.VK_8,
 		KeyEvent.VK_9
 	};
-	
+
 	private boolean showCandidates = Options.getInstance().isShowCandidates();
 	private boolean showWrongValues = Options.getInstance().isShowWrongValues();
 	private boolean showDeviations = Options.getInstance().isShowDeviations();
@@ -165,7 +165,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	private long lastCursorChanged = -1;
 	private RightClickMenu rightClickMenu = null;
 	private boolean[] remainingCandidates = new boolean[Sudoku2.UNITS];
-	
+
 	// event meta data
 	public int lastPressedRow = -1;
 	public int lastPressedCol = -1;
@@ -199,15 +199,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		isCtrlDown = false;
 		setActiveCell(4, 4);
 		//cellSelection.add(new Integer(Sudoku2.getIndex(4, 4)));
-		
+
 		clearDragSelection();
 		initComponents();
-		
+
 		rightClickMenu = new RightClickMenu(mf, this);
 		rightClickMenu.setColorIconsInPopupMenu();
 		updateCellZoomPanel();
 		calculateGridRegion(getBounds(), false, false);
-		
+
 		deleteCursorTimer.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -230,62 +230,62 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	private void clearDragSelection() {
 		Arrays.fill(dragCellSelection, false);
 	}
-	
+
 	public int getFirstRow() {
-		
+
 		if (cellSelection.isEmpty()) {
 			return -1;
 		}
-		
+
 		int index = cellSelection.get(0);
 		return Sudoku2.getRow(index);
 	}
-	
+
 	public int getFirstCol() {
-		
+
 		if (cellSelection.isEmpty()) {
 			return -1;
 		}
-		
+
 		int index = cellSelection.get(0);
 		return Sudoku2.getCol(index);
 	}
-	
+
 	public int getCellSelectionSize() {
 		return cellSelection.size();
 	}
-	
+
 	public int getActiveRow() {
-		
+
 		if (cellSelection.isEmpty()) {
 			return -1;
 		}
-		
+
 		int index = cellSelection.get(cellSelection.size()-1);
 		return Sudoku2.getRow(index);
 	}
-	
+
 	public int getActiveCol() {
-		
+
 		if (cellSelection.isEmpty()) {
 			return -1;
 		}
-		
+
 		int index = cellSelection.get(cellSelection.size()-1);
 		return Sudoku2.getCol(index);
 	}
-	
+
 	public Integer getActiveCell() {
-		
+
 		if (cellSelection.isEmpty()) {
 			return null;
 		}
-		
+
 		return new Integer(Sudoku2.getIndex(getActiveRow(), getActiveCol()));
 	}
-	
+
 	public void setActiveCell(int index) {
-		
+
 		Integer intObj = new Integer(index);
 
         if (Options.getInstance().isDeleteCursorDisplay()) {
@@ -294,44 +294,44 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
                 lastCursorChanged = System.currentTimeMillis();
                 deleteCursorTimer.setDelay(Options.getInstance().getDeleteCursorDisplayLength());
                 deleteCursorTimer.setInitialDelay(Options.getInstance().getDeleteCursorDisplayLength());
-                deleteCursorTimer.start();	
+                deleteCursorTimer.start();
         	}
         }
 
 		if (cellSelection.contains(intObj)) {
 			cellSelection.remove(intObj);
 		}
-		
+
 		cellSelection.add(intObj);
 		mainFrame.updateCellSelectionStatus();
 	}
-	
-	public void setActiveCell(int row, int col) {		
+
+	public void setActiveCell(int row, int col) {
 		setActiveCell(Sudoku2.getIndex(row, col));
 	}
-	
+
 	public void clearSelection(int lastCell) {
 		cellSelection.clear();
 		//cellSelection.add(new Integer(lastCell));
 		setActiveCell(lastCell);
 	}
-	
+
 	public void clearSelection(int row, int col) {
 		clearSelection(Sudoku2.getIndex(row, col));
 	}
-	
+
 	public void clearSelection() {
-		
+
 		if (cellSelection.isEmpty()) {
 			System.out.println("Error: SudokuPanel.clearSelection is empty...");
 		}
-		
+
 		Integer lastCell = cellSelection.get(cellSelection.size()-1);
 		cellSelection.clear();
 		//cellSelection.add(lastCell);
 		setActiveCell(lastCell);
 	}
-	
+
 	public void resetKeyState() {
 		isCtrlDown = false;
 	}
@@ -386,7 +386,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				if (!SwingUtilities.isLeftMouseButton(e)) {
 					return;
 				}
-				
+
 				if (!Sudoku2.isValidIndex(row, col)) {
 					return;
 				}
@@ -398,13 +398,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				if (!dragCellSelection[index]) {
 
 					dragCellSelection[index] = true;
-					if (cellSelection.contains(Integer.valueOf(index))) {						
-						cellSelection.remove(Integer.valueOf(index));					
-					} else {						
+					if (cellSelection.contains(Integer.valueOf(index))) {
+						cellSelection.remove(Integer.valueOf(index));
+					} else {
 						cellSelection.add(Integer.valueOf(index));
 					}
 				}
-				
+
 				setActiveCell(row, col);
 				repaint();
 			}
@@ -436,13 +436,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		layout.setVerticalGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING).addGap(0, 600, Short.MAX_VALUE));
 	}
-	
+
 	private Rectangle calculateGridRegion(Rectangle bounds, boolean isPrint, boolean withBorder) {
-		
+
 		// determine the actual size of the quad
 		int width = (bounds.height < bounds.width) ? bounds.height : bounds.width;
 		int height = (bounds.width < bounds.height) ? bounds.width : bounds.height;
-		
+
 		// make the size of the lines larger, especially for high res printing
 		this.strokeWidth = 2.0f / 1000.0f * width;
 		if (width > 1000) {
@@ -451,10 +451,10 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		this.boxStrokeWidth = (float) (this.strokeWidth * Options.getInstance().getBoxLineFactor());
 		this.strokeWidthInt = Math.round(this.boxStrokeWidth / 2);
-		
+
 		this.delta = bounds.width / 100;
 		this.deltaRand = bounds.width / 100;
-		
+
 		if (this.deltaRand < this.strokeWidthInt) {
 			this.deltaRand = this.strokeWidthInt;
 		}
@@ -462,30 +462,30 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		if (Options.getInstance().getDrawMode() == 1) {
 			this.delta = 0;
 		}
-		
+
 		// calculate the size of the cells and adjust for rounding errors
 		this.cellSize = (width - 4 * this.delta - 2 * this.deltaRand) / Sudoku2.UNITS;
 
 		width = height = this.cellSize * Sudoku2.UNITS + 4 * this.delta;
-		
+
 		int sx = (bounds.width - width) / 2;
 		int sy = (bounds.height - height) / 2;
-		
+
 		if (isPrint && withBorder) {
 			sy = 0;
 		}
-		
+
 		return new Rectangle(sx, sy, width, height);
 	}
-	
+
 	public boolean isOnGrid(Point point) {
-		
-		return 
+
+		return
 			point.x >= this.gridRegion.x &&
 			point.x < (this.gridRegion.x + this.gridRegion.width) &&
 			point.y >= this.gridRegion.y &&
 			point.y < (this.gridRegion.y + this.gridRegion.height);
-			
+
 	}
 
 	private void updateCandidateMouseHighlight(Point mouse) {
@@ -513,12 +513,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			}
 		}
 	}
-	
+
 	private void updateAutoHighlight(int row, int col) {
-		
+
 		if (Options.getInstance().isAutoHighlighting()) {
 			int value = sudoku.getValue(row, col);
-			
+
 			if (value != 0 && value != lastHighlightedDigit) {
 				setShowHintCellValue(value);
 				setShowInvalidOrPossibleCells(true);
@@ -537,16 +537,28 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		mainFrame.fixFocus();
 	}
 
-	private void onKeyPressed(java.awt.event.KeyEvent evt) {
+	public void resetColoring() {
+			cellZoomPanel.resetColoring();
+			clearColoring();
+			setActiveColor(null);
 
-		int keyCode = evt.getKeyCode();
-		switch (keyCode) {
-		case KeyEvent.VK_ESCAPE:
 			mainFrame.coloringPanelClicked(null);
 			clearRegion();
 			if (step != null) {
 				mainFrame.abortStep();
 			}
+			repaint();
+	}
+
+	private void onKeyPressed(java.awt.event.KeyEvent evt) {
+
+		int keyCode = evt.getKeyCode();
+		switch (keyCode) {
+		case KeyEvent.VK_ESCAPE:
+			resetColoring();
+			break;
+		case KeyEvent.VK_T:
+			cellZoomPanel.nextColoringMode();
 			break;
 		default:
 			handleKeys(evt);
@@ -570,31 +582,31 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		boolean isRightClick = evt.getButton() == MouseEvent.BUTTON3;
 		boolean rightClickOutsideSelection = !cellSelection.contains(Integer.valueOf(index)) && isRightClick;
 		boolean onGrid = isOnGrid(evt.getPoint());
-		
+
 		if (!onGrid) {
 
 			clearSelection();
 			clearDragSelection();
 			updateCellZoomPanel();
-			
+
 		} else if (rightClickOutsideSelection || cellZoomPanel.isColoring()) {
-			
+
 			if (rightClickOutsideSelection) {
 				setActiveCell(lastPressedRow, lastPressedCol);
 			}
-			
+
 			clearSelection();
 			clearDragSelection();
-			
+
 		} else if (isLeftClick) {
 
 			if (!isCtrlDown) {
-				
-				updateAutoHighlight(lastPressedRow, lastPressedCol);				
+
+				updateAutoHighlight(lastPressedRow, lastPressedCol);
 				setActiveCell(lastPressedRow, lastPressedCol);
 				clearSelection();
 				clearDragSelection();
-				
+
 			} else {
 
 				if (cellSelection.contains(index) && cellSelection.size() > 1) {
@@ -607,7 +619,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 			}
 		}
-		
+
 		repaint();
 	}
 
@@ -628,20 +640,20 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			clearSelection();
 			clearDragSelection();
 			updateCellZoomPanel();
-			
+
 			lastPressedRow = -1;
 			lastPressedCol = -1;
 			lastPressedCandidate = -1;
-			return;			
+			return;
 		}
-			
+
 		long ticks = System.currentTimeMillis();
 
-		boolean isDoubleClick = 
-			lastClickedTime != -1 && 
-			(ticks - lastClickedTime) <= doubleClickSpeed && 
-			row == lastClickedRow && 
-			col == lastClickedCol && 
+		boolean isDoubleClick =
+			lastClickedTime != -1 &&
+			(ticks - lastClickedTime) <= doubleClickSpeed &&
+			row == lastClickedRow &&
+			col == lastClickedCol &&
 			candidate == lastClickedCandidate;
 
 		if (isDoubleClick) {
@@ -658,77 +670,77 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	boolean onRightClick(MouseClickDTO dto) {
-		
+
 		boolean change = false;
-		
+
 		if (Options.getInstance().isSingleClickMode()) {
-			
+
 			// toggle candidate in cell(s) (three state mode)
 			if (cellSelection.contains(Integer.valueOf(Sudoku2.getIndex(dto.row, dto.col)))) {
-				
+
 				// a region select exists and the cells lies within: toggle candidate
 				if (dto.candidate != -1) {
 					change = toggleCandidateInAktCells(dto.candidate);
 				}
-				
+
 			} else {
-				
+
 				// no region or cell outside region -> change focus and toggle candidate
 				setActiveCell(dto.row, dto.col);
 				clearRegion();
-				
+
 				if (sudoku.getValue(dto.row, dto.col) != 0 && !sudoku.isFixed(dto.row, dto.col)) {
-					
+
 					rightClickMenu.deleteValuePopup(dto.row, dto.col, cellSize);
-					
+
 				} else {
-					
+
 					int showHintCellValue = getShowHintCellValue();
-					if ((dto.candidate == -1 || 
-						!sudoku.isCandidate(dto.row, dto.col, dto.candidate, !showCandidates)) && 
+					if ((dto.candidate == -1 ||
+						!sudoku.isCandidate(dto.row, dto.col, dto.candidate, !showCandidates)) &&
 						showHintCellValue != 0) {
-						
+
 						// if the candidate is not present, but part of the solution and
 						// show deviations is set, it is displayed, although technically
 						// not present: it should be toggled, even if it is not the
 						// hint value
-						if (showDeviations && 
-							sudoku.isSolutionSet() && 
+						if (showDeviations &&
+							sudoku.isSolutionSet() &&
 							dto.candidate == sudoku.getSolution(getActiveRow(), getActiveCol())) {
 							toggleCandidateInCell(getActiveRow(), getActiveCol(), dto.candidate);
 						} else {
 							toggleCandidateInCell(getActiveRow(), getActiveCol(), showHintCellValue);
 						}
-						
+
 					} else if (dto.candidate != -1) {
 						toggleCandidateInCell(getActiveRow(), getActiveCol(), dto.candidate);
 					}
-					
+
 					change = true;
 				}
 			}
-			
+
 		} else {
 			// bring up popup menu
 			rightClickMenu.showPopupMenu(dto.row, dto.col, cellSize);
 		}
-		
+
 		return change;
 	}
-	
+
 	boolean onSingleLeftClick(MouseClickDTO dto, int index) {
-		
+
 		if (dto.ctrlPressed) {
-			
+
 			/*
 			Integer cell = Integer.valueOf(index);
 
 			// select additional cell
 			if (cellSelection.size() == 0) {
-				
+
 				cellSelection.add(cell);
 				setActiveCell(dto.row, dto.col);
-							
+
 				if (!dragCellSelection[index]) {
 					if (cellSelection.contains(Integer.valueOf(index))) {
 						cellSelection.remove(Integer.valueOf(index));
@@ -736,15 +748,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						cellSelection.add(Integer.valueOf(index));
 					}
 				}
-				
-				setActiveCell(dto.row, dto.col);				
+
+				setActiveCell(dto.row, dto.col);
 			}*/
-			
-			return false;			
+
+			return false;
 		}
-		
+
 		if (dto.shiftPressed) {
-			
+
 			if (Options.getInstance().isUseShiftForRegionSelect()) {
 				// select range of cells
 				selectRegion(dto.row, dto.col);
@@ -756,31 +768,31 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					} else {
 						sudoku.setCandidate(index, dto.candidate, true, !showCandidates);
 					}
-					
+
 					clearRegion();
 					return true;
 				}
 			}
-			
-			return false;			
+
+			return false;
 		}
-		
+
 		// select single cell, delete old markings if available
 		// in the alternative mouse mode a single cell is only
 		// selected, if the cell is outside a selected region
-		if ((Options.getInstance().isSingleClickMode() == false && 
+		if ((Options.getInstance().isSingleClickMode() == false &&
 			cellSelection.contains(Integer.valueOf(Sudoku2.getIndex(dto.row, dto.col))) == false) ||
 			Options.getInstance().isSingleClickMode() == true) {
 			setActiveCell(dto.row, dto.col);
 			clearRegion();
 		}
-		
+
 		if (Options.getInstance().isSingleClickMode()) {
-			
+
 			// the selected cell(s) must be set to cand
 			if (sudoku.getValue(index) == 0) {
 				if (cellSelection.isEmpty()) {
-					
+
 					int showHintCellValue = getShowHintCellValue();
 					if (sudoku.getAnzCandidates(index, !showCandidates) == 1) {
 						// Naked single -> set it!
@@ -797,12 +809,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						if (sudoku.isCandidate(index, dto.candidate, !showCandidates)) {
 							setCell(dto.row, dto.col, dto.candidate);
 						}
-						
+
 						return true;
 					}
-					
+
 				} else {
-					
+
 					if (dto.candidate == -1 || !sudoku.isCandidate(index, dto.candidate, !showCandidates)) {
 						// an empty space was clicked in the cell -> clear region
 						setActiveCell(dto.row, dto.col);
@@ -812,12 +824,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						// still possible (collect cells first to avoid side effects!)
 						List<Integer> cells = new ArrayList<Integer>();
 						for (int selIndex : cellSelection) {
-							if (sudoku.getValue(selIndex) == 0 && 
+							if (sudoku.getValue(selIndex) == 0 &&
 								sudoku.isCandidate(selIndex, dto.candidate, !showCandidates)) {
 								cells.add(selIndex);
 							}
 						}
-						
+
 						for (int cellIndex : cells) {
 							setCell(Sudoku2.getRow(cellIndex), Sudoku2.getCol(cellIndex), dto.candidate);
 						}
@@ -826,35 +838,35 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			} else {
 				// clear selection
 				setActiveCell(dto.row, dto.col);
-				clearRegion();				
+				clearRegion();
 			}
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	boolean onDoubleLeftClick(MouseClickDTO dto, int index) {
-		
+
 		if (dto.ctrlPressed) {
 			if (dto.candidate != -1) {
-				
+
 				// toggle candidate
 				if (sudoku.isCandidate(index, dto.candidate, !showCandidates)) {
 					sudoku.setCandidate(index, dto.candidate, false, !showCandidates);
 				} else {
 					sudoku.setCandidate(index, dto.candidate, true, !showCandidates);
 				}
-				
+
 				clearRegion();
 				return true;
 			}
-			
+
 		} else {
-			
+
 			if (sudoku.getValue(index) == 0) {
-				
+
 				int showHintCellValue = getShowHintCellValue();
 				if (sudoku.getAnzCandidates(index, !showCandidates) == 1) {
 					// Naked single -> set it!
@@ -874,10 +886,10 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						setCell(dto.row, dto.col, dto.candidate);
 						setCandidateFilterByGiven(dto.row, dto.col);
 					}
-					
+
 					return true;
 				}
-				
+
 			} else if (!sudoku.isFixed(index)) {
 				// double clicking a user input value removes it
 				setCell(dto.row, dto.col, 0);
@@ -885,10 +897,10 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	void setCandidateFilterByGiven(int row, int col) {
 		if (Options.getInstance().isAutoHighlighting()) {
 			int value = sudoku.getValue(row, col);
@@ -905,28 +917,28 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			}
 		}
 	}
-	
+
 	boolean onLeftClick(MouseClickDTO dto) {
-		
+
 		boolean change = false;
-				
+
 		// in normal mode we only react to the left mouse button
 		int index = Sudoku2.getIndex(dto.row, dto.col);
 		if (dto.isDoubleClick) {
-			change = onDoubleLeftClick(dto, index);			
-		} else {			
+			change = onDoubleLeftClick(dto, index);
+		} else {
 			change = onSingleLeftClick(dto, index);
 		}
-		
+
 		return change;
 	}
-	
+
 	void onColoring(MouseClickDTO dto) {
-		
+
 		if (cellZoomPanel.isColoringCells()) {
 			// coloring for cells
 			if (dto.isCellClicked) {
-				handleColoring(dto.row, dto.col, -1, cellZoomPanel.getPrimaryColor());	
+				handleColoring(dto.row, dto.col, -1, cellZoomPanel.getPrimaryColor());
 			}
 		} else if (cellZoomPanel.isColoringCandidates()) {
 			// coloring for candidates
@@ -937,9 +949,9 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			}
 		}
 	}
-	
+
 	class MouseClickDTO {
-		
+
 		public int row;
 		public int col;
 		public int candidate;
@@ -952,7 +964,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		public boolean isCellClicked;
 		public boolean isCandidateClicked;
 		public boolean isDoubleClick;
-		
+
 		MouseClickDTO(MouseEvent e, SudokuPanel panel, boolean isDoubleClick) {
 			this.row = panel.getRow(e.getPoint());
 			this.col = panel.getCol(e.getPoint());
@@ -963,16 +975,16 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			this.isLeftClick = e.getButton() == MouseEvent.BUTTON1;
 			this.isMiddleClick = e.getButton() == MouseEvent.BUTTON2;
 			this.isRightClick = e.getButton() == MouseEvent.BUTTON3;
-			this.isCellClicked = 
-				this.row == panel.lastPressedRow && 
+			this.isCellClicked =
+				this.row == panel.lastPressedRow &&
 				this.col == panel.lastPressedCol;
-			this.isCandidateClicked = 
+			this.isCandidateClicked =
 				this.isCellClicked &&
 				this.candidate == panel.lastPressedCandidate;
 			this.isDoubleClick = isDoubleClick;
 		}
 	}
-	
+
 	/**
 	 * New mouse control for version 2.0:
 	 * <ul>
@@ -1007,30 +1019,30 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param evt
 	 */
 	private void handleMouseClicked(MouseEvent evt, boolean isDoubleClick) {
-		
+
 		MouseClickDTO dto = new MouseClickDTO(evt, this, isDoubleClick);
 		boolean changed = false;
-		
+
 		undoStack.push(sudoku.clone());
-		
+
 		if (dto.isValidCellIndex) {
-			if (dto.isRightClick) {				
-				changed = onRightClick(dto);				
+			if (dto.isRightClick) {
+				changed = onRightClick(dto);
 			} else {
 				if (cellZoomPanel.isColoring()) {
-					onColoring(dto);		
+					onColoring(dto);
 				} else if (dto.isLeftClick) {
-					changed = onLeftClick(dto);	
-				}				
+					changed = onLeftClick(dto);
+				}
 			}
-			
+
 			if (changed) {
 				redoStack.clear();
 				checkProgress();
 			} else {
 				undoStack.pop();
 			}
-			
+
 			updateCellZoomPanel();
 			mainFrame.check();
 			repaint();
@@ -1042,7 +1054,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		mainFrame.check();
 		repaint();
 	}
-	
+
 	/**
 	 * Moves the cursor. If the cell actually changed, a timer is started, that
 	 * triggers a repaint after {@link Options#getDeleteCursorDisplayLength() } ms.
@@ -1052,15 +1064,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 */
 	/*
 	private void setAktRowCol(int row, int col) {
-		
+
 		if (activeRow != row) {
 			activeRow = row;
 		}
-		
+
 		if (activeCol != col) {
 			activeCol = col;
 		}
-		
+
 		if (Options.getInstance().isDeleteCursorDisplay()) {
 			deleteCursorTimer.stop();
 			lastCursorChanged = System.currentTimeMillis();
@@ -1069,19 +1081,19 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			deleteCursorTimer.start();
 		}
 	}*/
-	
+
 	public void pushUndo() {
 		this.undoStack.push(this.sudoku.clone());
 	}
-	
+
 	public void popUndo() {
 		this.undoStack.pop();
 	}
-	
+
 	public void clearRedoStack() {
 		this.redoStack.clear();
 	}
-	
+
 	public ArrayList<Integer> getSelectedCells() {
 		return this.cellSelection;
 	}
@@ -1123,36 +1135,36 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param state
 	 */
 	public void setState(GuiState state) {
-		
+
 		chainIndex = state.getChainIndex();
 		if (state.getUndoStack() != null) {
 			undoStack = state.getUndoStack();
 		} else {
 			undoStack.clear();
 		}
-		
+
 		if (state.getRedoStack() != null) {
 			redoStack = state.getRedoStack();
 		} else {
 			redoStack.clear();
 		}
-		
+
 		if (state.getColoringMap() != null) {
 			coloringMap = state.getColoringMap();
 		} else {
 			coloringMap.clear();
 		}
-		
+
 		if (state.getColoringCandidateMap() != null) {
 			coloringCandidateMap = state.getColoringCandidateMap();
 		} else {
 			coloringCandidateMap.clear();
 		}
-		
+
 		sudoku = state.getSudoku();
 		sudoku.checkSudoku();
 		step = state.getStep();
-		
+
 		updateCellZoomPanel();
 		checkProgress();
 		mainFrame.check();
@@ -1161,10 +1173,10 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 	/*
 	public void loadFromFile(Sudoku sudoku, Sudoku solvedSudoku) {
-		
+
 		this.sudoku = sudoku;
 		this.solvedSudoku = solvedSudoku;
-		
+
 		redoStack.clear();
 		undoStack.clear();
 		coloringMap.clear();
@@ -1175,23 +1187,23 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		mainFrame.check();
 		repaint();
 	}*/
-	
+
 	private void checkShowAllCandidates(int modifiers, int keyCode) {
 
 		boolean oldShowAllCandidatesAkt = showAllCandidatesAkt;
 		showAllCandidatesAkt = false;
-		
+
 		if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0 && (modifiers & KeyEvent.CTRL_DOWN_MASK) != 0) {
 			showAllCandidatesAkt = true;
 		}
 
 		boolean oldShowAllCandidates = showAllCandidates;
 		showAllCandidates = false;
-		
+
 		if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0 && (modifiers & KeyEvent.ALT_DOWN_MASK) != 0) {
 			showAllCandidates = true;
 		}
-		
+
 		if (oldShowAllCandidatesAkt != showAllCandidatesAkt || oldShowAllCandidates != showAllCandidates) {
 			repaint();
 		}
@@ -1247,23 +1259,23 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		if (Character.isDigit(keyChar)) {
 			keyCode = KEY_CODES[keyChar - '0'];
 		}
-		
+
 		int number = 0;
 		boolean clearSelectedRegion = true;
 		switch (keyCode) {
 		case KeyEvent.VK_DOWN:
-			
-			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 && 
-				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0	&& 
+
+			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 &&
+				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0	&&
 				getShowHintCellValue() != 0) {
 				// go to next filtered candidate
 				int index = findNextHintCandidate(getFirstRow(), getFirstCol(), keyCode);
 				setActiveCell(Sudoku2.getRow(index), Sudoku2.getCol(index));
 			} else if (getActiveRow() < 8) {
-				
+
 				// go to the next row
 				setActiveCell(getActiveRow() + 1, getActiveCol());
-				
+
 				if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0) {
 					// go to the next unset cell
 					while (getActiveRow() < 8 && sudoku.getValue(getActiveRow(), getActiveCol()) != 0) {
@@ -1271,17 +1283,17 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				} else if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 					// expand the selected region
-					
+
 					setShift();
 					//setActiveCell(getActiveRow() - 1, getActiveCol());
 					//if (shiftRow < 8) {
 					//	shiftRow++;
 					//}
-					
+
 					selectRegion(shiftRow, shiftCol);
 					clearSelectedRegion = false;
 				}
-				
+
 			} else if (getActiveRow() == 8) {
 				setActiveCell(0, getActiveCol());
 			}
@@ -1292,8 +1304,8 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 			break;
 		case KeyEvent.VK_UP:
-			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 && 
-				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0 && 
+			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 &&
+				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0 &&
 				getShowHintCellValue() != 0) {
 				// go to next filtered candidate
 				int index = findNextHintCandidate(getFirstRow(), getFirstCol(), keyCode);
@@ -1308,14 +1320,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				} else if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 					// expand the selected region
-					
+
 					setShift();
 					//setActiveCell(getActiveRow() + 1, getActiveCol());
-					
+
 					//if (shiftRow > 0) {
 					//	shiftRow--;
 					//}
-					
+
 					selectRegion(shiftRow, shiftCol);
 					clearSelectedRegion = false;
 				}
@@ -1329,7 +1341,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 			break;
 		case KeyEvent.VK_RIGHT:
-			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 && 
+			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 &&
 				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0 &&
 				getShowHintCellValue() != 0) {
 				// go to next filtered candidate
@@ -1345,14 +1357,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				} else if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 					// expand the selected region
-					
+
 					setShift();
 					//setActiveCell(getActiveRow(), getActiveCol() - 1);
-					
+
 					//if (shiftCol < 8) {
 					//	shiftCol++;
 					//}
-					
+
 					selectRegion(shiftRow, shiftCol);
 					clearSelectedRegion = false;
 				}
@@ -1366,8 +1378,8 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 			break;
 		case KeyEvent.VK_LEFT:
-			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 && 
-				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0	&& 
+			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 &&
+				(modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0	&&
 				getShowHintCellValue() != 0) {
 				// go to next filtered candidate
 				int index = findNextHintCandidate(getFirstRow(), getFirstCol(), keyCode);
@@ -1382,14 +1394,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				} else if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 					// expand the selected region
-					
+
 					setShift();
 					//setActiveCell(getActiveRow(), getActiveCol() + 1);
-					
+
 					//if (shiftCol > 0) {
 					//	shiftCol--;
 					//}
-					
+
 					selectRegion(shiftRow, shiftCol);
 					clearSelectedRegion = false;
 				}
@@ -1404,14 +1416,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			break;
 		case KeyEvent.VK_HOME:
 			if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
-				
+
 				setShift();
 				if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0) {
 					shiftRow = 0;
 				} else {
 					shiftCol = 0;
 				}
-				
+
 				selectRegion(shiftRow, shiftCol);
 				clearSelectedRegion = false;
 			} else {
@@ -1421,11 +1433,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					setActiveCell(getActiveRow(), 0);
 				}
 			}
-			
+
 			if (clearSelectedRegion) {
 				clearRegion();
 			}
-			
+
 			break;
 		case KeyEvent.VK_END:
 			if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
@@ -1435,23 +1447,23 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				} else {
 					shiftCol = 8;
 				}
-				
+
 				selectRegion(shiftRow, shiftCol);
 				clearSelectedRegion = false;
-				
+
 			} else {
-				
+
 				if ((modifiers & KeyEvent.CTRL_DOWN_MASK) != 0) {
 					setActiveCell(8, getActiveCol());
 				} else {
 					setActiveCell(getActiveRow(), 8);
 				}
 			}
-			
+
 			if (clearSelectedRegion) {
 				clearRegion();
 			}
-			
+
 			break;
 		case KeyEvent.VK_ENTER: {
 			int index = Sudoku2.getIndex(getActiveRow(), getActiveCol());
@@ -1510,11 +1522,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						}
 					}
 				} else {
-					
+
 					// set value only in cells where the candidate is still present
 					// problem: setting the first removes all other candidates in the
 					// corresponding blocks so we have to collect the applicable cells first
-					
+
 					/*
 					List<Integer> cells = new ArrayList<Integer>();
 					for (int index : cellSelection) {
@@ -1522,25 +1534,25 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 							cells.add(index);
 						}
 					}*/
-					
+
 					List<Integer> cells = new ArrayList<Integer>(cellSelection);
 					Integer activeIndex = new Integer(Sudoku2.getIndex(getActiveRow(), getActiveCol()));
 					if (!cells.contains(activeIndex)) {
 						cells.add(activeIndex);
 					}
-					
+
 					if (cells.size() == 1) {
 						setCell(getActiveRow(), getActiveCol(), number);
 						setCandidateFilterByGiven(getActiveRow(), getActiveCol());
 					} else {
 						for (int index : cells) {
 							setCell(Sudoku2.getRow(index), Sudoku2.getCol(index), number);
-						}	
+						}
 					}
 				}
-				
+
 				changed = true;
-				
+
 			} else {
 				// only when shift is NOT pressed (if pressed its a menu accelerator)
 				// 20120115: the accelerators have been removed!
@@ -1551,21 +1563,21 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					changed = toggleCandidateInAktCells(number);
 				}
 			}
-			
+
 			break;
 		case KeyEvent.VK_BACK_SPACE:
 		case KeyEvent.VK_DELETE:
 		case KeyEvent.VK_0:
 		case KeyEvent.VK_NUMPAD0:
-			
+
 			if ((modifiers & KeyEvent.CTRL_DOWN_MASK) == 0) {
-				
+
 				if (sudoku.getValue(getActiveRow(), getActiveCol()) != 0 && !sudoku.isFixed(getActiveRow(), getActiveCol())) {
 					sudoku.setCell(getActiveRow(), getActiveCol(), 0);
 					setCandidateFilterByGiven(getActiveRow(), getActiveCol());
 					changed = true;
 				}
-				
+
 				if (mainFrame.isInputMode() && Options.getInstance().isEditModeAutoAdvance()) {
 					// automatically advance to the next cell
 					if (getActiveCol() < 8) {
@@ -1575,11 +1587,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			break;
 		case KeyEvent.VK_F10:
-			if ((modifiers & KeyEvent.ALT_DOWN_MASK) == 0) {				
-				
+			if ((modifiers & KeyEvent.ALT_DOWN_MASK) == 0) {
+
 				if (showHintCellValues[10]) {
 					showHintCellValues[10] = false;
 					resetShowHintCellValues();
@@ -1620,7 +1632,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					// no bivalue cells!
 					showHintCellValues[10] = false;
 				} else {
-					
+
 					if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 						invalidCells = !invalidCells;
 					}
@@ -1647,24 +1659,24 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		case KeyEvent.VK_B:
 			number++;
 		case KeyEvent.VK_A:
-			
+
 			// if ctrl or alt or meta is pressed, it's a shortcut
-			if ((modifiers & KeyEvent.ALT_DOWN_MASK) != 0 || 
-				(modifiers & KeyEvent.ALT_GRAPH_DOWN_MASK) != 0	|| 
-				(modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 || 
+			if ((modifiers & KeyEvent.ALT_DOWN_MASK) != 0 ||
+				(modifiers & KeyEvent.ALT_GRAPH_DOWN_MASK) != 0	||
+				(modifiers & KeyEvent.CTRL_DOWN_MASK) != 0 ||
 				(modifiers & KeyEvent.META_DOWN_MASK) != 0) {
 				// do nothing!
 				break;
 			}
-			
+
 			// calculate index in coloringColors[]
 			number *= 2;
 			if ((modifiers & KeyEvent.SHIFT_DOWN_MASK) != 0) {
 				number++;
 			}
-			
+
 			handleColoring(-1, Options.getInstance().getColoringColors()[number]);
-			
+
 			break;
 		case KeyEvent.VK_R:
 			clearColoring();
@@ -1692,7 +1704,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 							}
 						}
 					}
-					
+
 					int count = 0;
 					do {
 						if (isUp) {
@@ -1708,7 +1720,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						}
 						count++;
 					} while (count < 8 && (Sudoku2.MASKS[cand] & rem) == 0);
-					
+
 					if (count < 8) {
 						// if only one candidate is left for filtering,
 						// it would be toggled without this check
@@ -1717,17 +1729,17 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			break;
 		}
-		
+
 		if (changed) {
 			redoStack.clear();
 			checkProgress();
 		} else {
 			undoStack.pop();
 		}
-		
+
 		updateCellZoomPanel();
 		mainFrame.check();
 		repaint();
@@ -1741,7 +1753,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		clearSelection();
 		shiftRow = -1;
 		shiftCol = -1;
-		
+
 		Integer index = Integer.valueOf(Sudoku2.getIndex(getActiveRow(), getActiveCol()));
 		if (!cellSelection.contains(index)) {
 			//cellSelection.add(index);
@@ -1757,25 +1769,25 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param col
 	 */
 	private void selectRegion(int row, int col) {
-		
+
 		Integer startIndex = Integer.valueOf(Sudoku2.getIndex(getFirstRow(), getFirstCol()));
 		Integer endIndex = Integer.valueOf(Sudoku2.getIndex(getActiveRow(), getActiveCol()));
-		
+
 		//clearSelection();
 		if (row == getActiveRow() && col == getActiveCol()) {
 			// same cell clicked twice -> no region selected -> do nothing
 		} else {
-			
+
 			// every cell in the region gets selected, aktRow and aktCol are not changed
 			int cStart = col < getActiveCol() ? col : getActiveCol();
 			int rStart = row < getActiveRow() ? row : getActiveRow();
 			int cEnd = cStart + Math.abs(col - getActiveCol());
 			int rEnd = rStart + Math.abs(row - getActiveRow());
-			
+
 			// make sure selection starts with the same index.
 			cellSelection.clear();
 			cellSelection.add(startIndex);
-			
+
 			for (int c = cStart; c <= cEnd; c++) {
 				for (int r = rStart; r <= rEnd; r++) {
 					Integer cv = Integer.valueOf(Sudoku2.getIndex(r, c));
@@ -1784,7 +1796,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			// fix the end index (just in case)
 			setActiveCell(endIndex);
 			/*
@@ -1828,7 +1840,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		switch (mode) {
 		case KeyEvent.VK_DOWN:
-			
+
 			// let's start with the next row
 			row++;
 			if (row == Sudoku2.UNITS) {
@@ -1838,7 +1850,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					return index;
 				}
 			}
-			
+
 			for (int i = col; i < Sudoku2.UNITS; i++) {
 				int j = i == col ? row : 0;
 				for (; j < Sudoku2.UNITS; j++) {
@@ -1847,7 +1859,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			break;
 		case KeyEvent.VK_UP:
 			// let's start with the previous row
@@ -1859,7 +1871,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					return index;
 				}
 			}
-			
+
 			for (int i = col; i >= 0; i--) {
 				int j = i == col ? row : 8;
 				for (; j >= 0; j--) {
@@ -1875,18 +1887,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			if (index < 0) {
 				return index + 1;
 			}
-			
+
 			while (index >= 0) {
 				if (sudoku.getValue(index) == 0 && sudoku.isCandidate(index, showHintCellValue, !showCandidates)) {
 					return index;
 				}
 				index--;
 			}
-			
+
 			if (index < 0) {
 				index = Sudoku2.getIndex(row, col);
 			}
-			
+
 			break;
 		case KeyEvent.VK_RIGHT:
 			// lets start right
@@ -1894,30 +1906,30 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			if (index >= sudoku.getCells().length) {
 				return index - 1;
 			}
-			
+
 			while (index < sudoku.getCells().length) {
 				if (sudoku.getValue(index) == 0 && sudoku.isCandidate(index, showHintCellValue, !showCandidates)) {
 					return index;
 				}
 				index++;
 			}
-			
+
 			if (index >= sudoku.getCells().length) {
 				index = Sudoku2.getIndex(row, col);
 			}
-			
+
 			break;
 		}
 		return index;
 	}
-	
+
 	public void clearCandidateColors() {
 		coloringCandidateMap.clear();
 		coloringCandidateMap.clear();
 		updateCellZoomPanel();
 		mainFrame.check();
 	}
-	
+
 	public void clearCellColors() {
 		coloringMap.clear();
 		coloringMap.clear();
@@ -1953,14 +1965,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	public Color getActiveColor() {
-		
+
 		if (cellZoomPanel.isDefaultMouse()) {
 			return null;
 		}
-		
+
 		return cellZoomPanel.getPrimaryColor();
 	}
-	
+
 	/**
 	 * Toggles Color for candidate in active cell; only called from
 	 * {@link CellZoomPanel}.
@@ -1988,18 +2000,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param colorNumber
 	 */
 	public void handleColoring(int row, int col, int candidate, Color color) {
-		
+
 		if (!Options.getInstance().isColorValues() && sudoku.getValue(row, col) != 0) {
 			return;
 		}
-		
+
 		SortedMap<Integer, Color> map = coloringMap;
 		int key = Sudoku2.getIndex(row, col);
 		if (candidate != -1) {
 			key = key * 10 + candidate;
 			map = coloringCandidateMap;
 		}
-		
+
 		if (map.containsKey(key) && map.get(key) == color) {
 			// pressing the same key on the same cell twice removes the coloring
 			map.remove(key);
@@ -2007,7 +2019,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			// either newly colored cell or change of cell color
 			map.put(key, color);
 		}
-		
+
 		updateCellZoomPanel();
 	}
 
@@ -2018,7 +2030,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param number
 	 */
 	public void setCellFromCellZoomPanel(int number) {
-		
+
 		undoStack.push(sudoku.clone());
 		if (cellSelection.isEmpty()) {
 			setCell(getActiveRow(), getActiveCol(), number);
@@ -2027,7 +2039,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				setCell(Sudoku2.getRow(index), Sudoku2.getCol(index), number);
 			}
 		}
-		
+
 		updateCellZoomPanel();
 		mainFrame.check();
 		repaint();
@@ -2037,14 +2049,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		int index = Sudoku2.getIndex(row, col);
 		if (!sudoku.isFixed(index) && sudoku.getValue(index) != number) {
-			
+
 			if (sudoku.getValue(index) != 0) {
 				sudoku.setCell(row, col, 0);
 			}
-			
+
 			sudoku.setCell(row, col, number);
 			repaint();
-			
+
 			if (sudoku.isSolved() && Options.getInstance().isShowSudokuSolved()) {
 				JOptionPane.showMessageDialog(
 					this,
@@ -2065,13 +2077,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return <code>true</code>, if at least one cell was changed
 	 */
 	private boolean toggleCandidateInAktCells(int candidate) {
-		
+
 		boolean changed = false;
 		if (cellSelection.isEmpty()) {
 			toggleCandidateInCell(getActiveRow(), getActiveCol(), candidate);
 			return true;
 		} else {
-			
+
 			boolean candPresent = false;
 			for (int index : cellSelection) {
 				if (sudoku.getValue(index) == 0 && sudoku.isCandidate(index, candidate, !showCandidates)) {
@@ -2079,7 +2091,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					break;
 				}
 			}
-			
+
 			for (int index : cellSelection) {
 				if (candPresent) {
 					if (sudoku.getValue(index) == 0 && sudoku.isCandidate(index, candidate, !showCandidates)) {
@@ -2094,7 +2106,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 			}
 		}
-		
+
 		updateCellZoomPanel();
 		return changed;
 	}
@@ -2108,7 +2120,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param candidate
 	 */
 	private void toggleCandidateInCell(int row, int col, int candidate) {
-		
+
 		int index = Sudoku2.getIndex(row, col);
 		if (sudoku.getValue(index) == 0) {
 			if (sudoku.isCandidate(index, candidate, !showCandidates)) {
@@ -2117,7 +2129,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				sudoku.setCandidate(index, candidate, true, !showCandidates);
 			}
 		}
-		
+
 		updateCellZoomPanel();
 	}
 
@@ -2187,7 +2199,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 	@Override
 	public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
-		
+
 		if (pageIndex > 0) {
 			return Printable.NO_SUCH_PAGE;
 		}
@@ -2197,7 +2209,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		// To print in high resolution this downscaling has to be reverted.
 		Graphics2D printG2 = (Graphics2D) graphics;
 		double scale = SudokuUtil.adjustGraphicsForPrinting(printG2);
-		
+
 		printG2.translate((int) (pageFormat.getImageableX() * scale), (int) (pageFormat.getImageableY() * scale));
 		int printWidth = (int) (pageFormat.getImageableWidth() * scale);
 		int printHeight = (int) (pageFormat.getImageableHeight() * scale);
@@ -2261,20 +2273,20 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param scale       Necessary for high resolution printing
 	 */
 	private void drawPage(
-			int totalWidth, 
-			int totalHeight, 
-			boolean isPrint, 
-			boolean withBorder, 
+			int totalWidth,
+			int totalHeight,
+			boolean isPrint,
+			boolean withBorder,
 			boolean allBlack,
 			double scale) {
 
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-		
+
 		if (lastCursorChanged == -1) {
 			lastCursorChanged = System.currentTimeMillis();
 		}
-		
+
 		gridRegion = calculateGridRegion(new Rectangle(0, 0, totalWidth, totalHeight), isPrint, withBorder);
 
 		int colorKuCellSize = (int) (cellSize * 0.9);
@@ -2283,11 +2295,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		// the user selects a different font in the preferences dialog
 		Font tmpFont = Options.getInstance().getDefaultValueFont();
 		if (valueFont != null) {
-			if (!valueFont.getName().equals(tmpFont.getName()) || 
-				valueFont.getStyle() != tmpFont.getStyle() || 
+			if (!valueFont.getName().equals(tmpFont.getName()) ||
+				valueFont.getStyle() != tmpFont.getStyle() ||
 				valueFont.getSize() != ((int) (cellSize * Options.getInstance().getValueFontFactor()))) {
 				valueFont = new Font(
-					tmpFont.getName(), 
+					tmpFont.getName(),
 					tmpFont.getStyle(),
 					(int) (cellSize * Options.getInstance().getValueFontFactor())
 				);
@@ -2296,20 +2308,20 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		tmpFont = Options.getInstance().getDefaultCandidateFont();
 		if (candidateFont != null) {
-			if (!candidateFont.getName().equals(tmpFont.getName()) || 
-				candidateFont.getStyle() != tmpFont.getStyle() || 
+			if (!candidateFont.getName().equals(tmpFont.getName()) ||
+				candidateFont.getStyle() != tmpFont.getStyle() ||
 				candidateFont.getSize() != ((int) (cellSize * Options.getInstance().getCandidateFontFactor()))) {
-				
+
 				int oldCandidateHeight = candidateHeight;
 				candidateFont = new Font(
-					tmpFont.getName(), 
+					tmpFont.getName(),
 					tmpFont.getStyle(),
 					(int) (cellSize * Options.getInstance().getCandidateFontFactor())
 				);
-				
+
 				FontMetrics cm = getFontMetrics(candidateFont);
 				candidateHeight = (int) ((cm.getAscent() - cm.getDescent()) * 1.3);
-				
+
 				if (candidateHeight != oldCandidateHeight) {
 					resetColorKuImages();
 				}
@@ -2317,7 +2329,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		}
 
 		if (oldWidth != gridRegion.width) {
-			
+
 			int oldCandidateHeight = candidateHeight;
 			oldWidth = gridRegion.width;
 			valueFont = new Font(
@@ -2330,10 +2342,10 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				Options.getInstance().getDefaultCandidateFont().getStyle(),
 				(int) (cellSize * Options.getInstance().getCandidateFontFactor())
 			);
-			
+
 			FontMetrics cm = getFontMetrics(candidateFont);
 			candidateHeight = (int) ((cm.getAscent() - cm.getDescent()) * 1.3);
-			
+
 			if (candidateHeight != oldCandidateHeight) {
 				resetColorKuImages();
 			}
@@ -2356,22 +2368,22 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 
 				int cellIndex = Sudoku2.getIndex(row, col);
-				boolean isSelected = 
-					(row == getActiveRow() && col == getActiveCol()) || 
+				boolean isSelected =
+					(row == getActiveRow() && col == getActiveCol()) ||
 					cellSelection.contains(Integer.valueOf(cellIndex));
-				
+
 				// the cell doesn't count as selected, if the last change of the cursor has been a while
 				if (isSelected && cellSelection.size() == 1 && Options.getInstance().isDeleteCursorDisplay()) {
 					if ((System.currentTimeMillis() - lastCursorChanged) > Options.getInstance().getDeleteCursorDisplayLength()) {
 						isSelected = false;
 					}
 				}
-				
+
 				// don't paint the whole cell yellow, just a small frame, if onlySmallCursors is set
 				if (isSelected && !isPrint && !Options.getInstance().isOnlySmallCursors()) {
 					setColor(g2, allBlack, Options.getInstance().getAktCellColor());
 				}
-				
+
 				// check if the candidate denoted by showHintCellValue is a valid candidate; if
 				// showCandidates == true,
 				// this can be done by SudokuCell.isCandidateValid(); if it is false, candidates
@@ -2384,31 +2396,31 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						candidateValid = sudoku.areCandidatesValid(cellIndex, showHintCellValues, false);
 					}
 				}
-				
+
 				boolean isHighlightingBivalue = showHintCellValues[10];
 				boolean isCellBivalue = sudoku.getAllCandidates(cellIndex).length == 2;
-				
+
 				// highlight (filter)
 				if (isShowInvalidOrPossibleCells()) {
-					
+
 					if (!isInvalidCells()) {
-						
+
 						// highlighting
-						if (sudoku.getValue(cellIndex) == 0 && 
-							candidateValid && 
+						if (sudoku.getValue(cellIndex) == 0 &&
+							candidateValid &&
 							!Options.getInstance().isOnlySmallFilters()) {
 							setColor(g2, allBlack, Options.getInstance().getPossibleCellColor());
-						} else if (Options.getInstance().isHighlightingGivens() && 
+						} else if (Options.getInstance().isHighlightingGivens() &&
 								   sudoku.getValue(cellIndex) != 0 &&
 								   showHintCellValues[sudoku.getValue(cellIndex)]) {
 							setColor(g2, allBlack, Options.getInstance().getPossibleFixedCellColor());
 						}
-						
+
 					} else {
-						
+
 						// inverse highlight
-						if (isInvalidCells() && 
-							(sudoku.getValue(cellIndex) != 0 || 
+						if (isInvalidCells() &&
+							(sudoku.getValue(cellIndex) != 0 ||
 							(showInvalidOrPossibleCells && !candidateValid))) {
 							setColor(g2, allBlack, Options.getInstance().getInvalidCellColor());
 						}
@@ -2416,30 +2428,30 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 
 				// coloring
-				if (coloringMap.containsKey(cellIndex) && 
-					(sudoku.getValue(cellIndex) == 0 || 
+				if (coloringMap.containsKey(cellIndex) &&
+					(sudoku.getValue(cellIndex) == 0 ||
 					Options.getInstance().isColorValues()) &&
 					isColoringVisible) {
 					setColor(g2, allBlack, coloringMap.get(cellIndex));
 				}
-				
+
 				// draw the cell background
 				int cellX = getX(row, col);
 				int cellY = getY(row, col);
 				g2.fillRect(cellX, cellY, cellSize, cellSize);
-				
+
 				// draw cell selection
 				if (isSelected && !isPrint && g2.getColor() != Options.getInstance().getAktCellColor()) {
-					
+
 					setColor(g2, allBlack, Options.getInstance().getAktCellColor());
-					
+
 					int frameSize = (int) (cellSize * Options.getInstance().getCursorFrameSize());
-					
+
 					// make cell selection border smaller then the main selector
 					if (row != getActiveRow() || col != getActiveCol()) {
 						frameSize = frameSize / 2 + 1;
 					}
-					
+
 					/*
 					if (row == activeRow && col == getActiveCol()) {
 						g2.setColor(new Color(0.1f, 0.3f, 0.7f, 0.1f));
@@ -2447,25 +2459,25 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						g2.setColor(new Color(0.1f, 0.3f, 0.7f, 0.5f));
 						frameSize = 1;
 					}*/
-				
+
 					((Graphics)g2).fillRect(cellX, cellY, cellSize, frameSize+1);
 					((Graphics)g2).fillRect(cellX, cellY, frameSize+1, cellSize);
 					((Graphics)g2).fillRect(cellX + cellSize - frameSize, cellY, frameSize, cellSize);
-					((Graphics)g2).fillRect(cellX, cellY + cellSize - frameSize, cellSize, frameSize);	
+					((Graphics)g2).fillRect(cellX, cellY + cellSize - frameSize, cellSize, frameSize);
 				}
 
 				if (showCandidateHighlight()) {
 
 					// draw candidate mouse highlight
-					if (lastCandidateMouseOn != null && 
-						lastCandidateMouseOn.getIndex() >= 0 && 
+					if (lastCandidateMouseOn != null &&
+						lastCandidateMouseOn.getIndex() >= 0 &&
 						lastCandidateMouseOn.getIndex() < Sudoku2.LENGTH) {
 
 						int cellColumn = lastCandidateMouseOn.getIndex() % Sudoku2.UNITS;
 						int cellRow = lastCandidateMouseOn.getIndex() / Sudoku2.UNITS;
 
-						if (row == cellRow && 
-							col == cellColumn && 
+						if (row == cellRow &&
+							col == cellColumn &&
 							sudoku.getValue(lastCandidateMouseOn.getIndex()) == 0) {
 
 							int startX = getX(cellRow, cellColumn);
@@ -2486,7 +2498,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 							if (!sudoku.isCandidate(lastCandidateMouseOn.getIndex(), lastCandidateMouseOn.getValue())) {
 								g2.setColor(new Color(0.2f, 0.2f, 0.2f, 0.3f));
 								g2.drawString(
-									Integer.toString(candidate), 
+									Integer.toString(candidate),
 									(int) Math.round(startX + dcx + shiftX),
 									(int) Math.round(startY + dcy + shiftY)
 								);
@@ -2506,7 +2518,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				Color offColor = null;
 				int offCand = 0;
 				if (sudoku.getValue(cellIndex) != 0) {
-					
+
 					// value set in cell: draw it
 					setColor(g2, allBlack, Options.getInstance().getCellValueColor());
 					if (sudoku.isFixed(cellIndex)) {
@@ -2520,18 +2532,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 						offCand = 11;
 						setColor(g2, allBlack, Options.getInstance().getDeviationColor());
 					}
-					
+
 					g2.setFont(valueFont);
 					dx = (cellSize - g2.getFontMetrics().stringWidth("8")) / 2.0;
 					dy = (cellSize + g2.getFontMetrics().getAscent() - g2.getFontMetrics().getDescent()) / 2.0;
 					int value = sudoku.getValue(cellIndex);
 					if (Options.getInstance().isShowColorKuAct()) {
-						
+
 						// draw the corresponding icon
 						drawColorBox(
-							value, g2, 
+							value, g2,
 							getX(row, col) + (cellSize - colorKuCellSize) / 2,
-							getY(row, col) + (cellSize - colorKuCellSize) / 2, 
+							getY(row, col) + (cellSize - colorKuCellSize) / 2,
 							colorKuCellSize, true
 						);
 
@@ -2540,14 +2552,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 							setColor(g2, allBlack, offColor);
 							g2.drawString("X", (int) (startX + dx), (int) (startY + dy));
 						}
-						
+
 					} else {
 						// draw the value
 						g2.drawString(Integer.toString(value), (int) (startX + dx), (int) (startY + dy));
 					}
 
 				} else {
-					
+
 					// draw the candidates equally distributed within the cell
 					// if showCandidates is false, the candidates are drawn anyway, if
 					// the user presses <shift><ctrl> (current cell - showAllCandidatesAkt)
@@ -2557,7 +2569,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					if (showAllCandidates || showAllCandidatesAkt && row == getActiveRow() && col == getActiveCol()) {
 						userCandidates = false;
 					}
-					
+
 					// calculate the width of the space for one candidate
 					double third = cellSize / 3.0;
 					dcx = (third - g2.getFontMetrics().stringWidth("8")) / 2.0;
@@ -2565,18 +2577,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					ddy = (g2.getFontMetrics().getAscent() - g2.getFontMetrics().getDescent()) * Options.getInstance().getHintBackFactor();
 
 					for (int i = 1; i <= Sudoku2.UNITS; i++) {
-						
+
 						offColor = null;
 						// one candidate at a time
-						if (sudoku.isCandidate(cellIndex, i, userCandidates) || 
+						if (sudoku.isCandidate(cellIndex, i, userCandidates) ||
 							(showCandidates && showDeviations && sudoku.isSolutionSet() && i == sudoku.getSolution(cellIndex))) {
-							
+
 							Color hintColor = null;
 							Color candColor = null;
 							candColor = Options.getInstance().getCandidateColor();
 							double shiftX = ((i - 1) % 3) * third;
 							double shiftY = ((i - 1) / 3) * third;
-							
+
 							if (Options.getInstance().isShowColorKuAct()) {
 								// Colorku has to be drawm here, or filters, coloring, hints wont be visible
 								int ccx = (int) Math.round(startX + shiftX + third / 2.0 - candidateHeight / 2.0);
@@ -2585,13 +2597,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 							}
 
 							if (step != null) {
-								
+
 								int index = Sudoku2.getIndex(row, col);
 								if (step.getIndices().indexOf(index) >= 0 && step.getValues().indexOf(i) >= 0) {
 									hintColor = Options.getInstance().getHintCandidateBackColor();
 									candColor = Options.getInstance().getHintCandidateColor();
 								}
-								
+
 								int alsIndex = step.getAlsIndex(index, chainIndex);
 								if (alsIndex != -1 && ((chainIndex == -1 && !step.getType().isKrakenFish())
 										|| alsToShow.contains(alsIndex))) {
@@ -2600,38 +2612,38 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 									candColor = Options.getInstance().getHintCandidateAlsColors()[alsIndex
 											% Options.getInstance().getHintCandidateAlsColors().length];
 								}
-								
+
 								for (int k = 0; k < step.getChains().size(); k++) {
-									
+
 									if (step.getType().isKrakenFish() && chainIndex == -1) {
 										// Index 0 means show no chain at all
 										continue;
 									}
-									
+
 									if (chainIndex != -1 && k != chainIndex) {
 										// show only one chain in Forcing Chains/Nets
 										continue;
 									}
-									
+
 									Chain chain = step.getChains().get(k);
 									for (int j = chain.getStart(); j <= chain.getEnd(); j++) {
 										if (chain.getChain()[j] == Integer.MIN_VALUE) {
 											// Trennmarker fï¿½r mins -> ignorieren
 											continue;
 										}
-										
+
 										int chainEntry = Math.abs(chain.getChain()[j]);
 										int index1 = -1, index2 = -1, index3 = -1;
 										if (Chain.getSNodeType(chainEntry) == Chain.NORMAL_NODE) {
 											index1 = Chain.getSCellIndex(chainEntry);
 										}
-										
+
 										if (Chain.getSNodeType(chainEntry) == Chain.GROUP_NODE) {
 											index1 = Chain.getSCellIndex(chainEntry);
 											index2 = Chain.getSCellIndex2(chainEntry);
 											index3 = Chain.getSCellIndex3(chainEntry);
 										}
-										
+
 										if ((index == index1 || index == index2 || index == index3)
 												&& Chain.getSCandidate(chainEntry) == i) {
 											if (Chain.isSStrong(chainEntry)) {
@@ -2645,34 +2657,34 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 										}
 									}
 								}
-								
+
 								for (Candidate cand : step.getFins()) {
 									if (cand.getIndex() == index && cand.getValue() == i) {
 										hintColor = Options.getInstance().getHintCandidateFinBackColor();
 										candColor = Options.getInstance().getHintCandidateFinColor();
 									}
 								}
-								
+
 								for (Candidate cand : step.getEndoFins()) {
 									if (cand.getIndex() == index && cand.getValue() == i) {
 										hintColor = Options.getInstance().getHintCandidateEndoFinBackColor();
 										candColor = Options.getInstance().getHintCandidateEndoFinColor();
 									}
 								}
-								
+
 								if (step.getValues().contains(i) && step.getColorCandidates().containsKey(index)) {
 									hintColor = Options.getInstance().getColoringColors()[step.getColorCandidates()
 											.get(index)];
 									candColor = Options.getInstance().getCandidateColor();
 								}
-								
+
 								for (Candidate cand : step.getCandidatesToDelete()) {
 									if (cand.getIndex() == index && cand.getValue() == i) {
 										hintColor = Options.getInstance().getHintCandidateDeleteBackColor();
 										candColor = Options.getInstance().getHintCandidateDeleteColor();
 									}
 								}
-								
+
 								for (Candidate cand : step.getCannibalistic()) {
 									if (cand.getIndex() == index && cand.getValue() == i) {
 										hintColor = Options.getInstance().getHintCandidateCannibalisticBackColor();
@@ -2680,41 +2692,41 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 									}
 								}
 							}
-							
+
 							if (isShowWrongValues() == true && !sudoku.isCandidateValid(cellIndex, i, userCandidates)) {
 								offColor = Options.getInstance().getColorKuColor(10);
 								offCand = 10;
 								candColor = Options.getInstance().getWrongValueColor();
 							}
-							
+
 							if (!sudoku.isCandidate(cellIndex, i, userCandidates) && isShowDeviations()
 									&& sudoku.isSolutionSet() && i == sudoku.getSolution(cellIndex)) {
 								offColor = Options.getInstance().getColorKuColor(11);
 								offCand = 11;
 								candColor = Options.getInstance().getDeviationColor();
 							}
-							
-							boolean isFilteringCandidates = 
-									isShowInvalidOrPossibleCells() && 
-									!isInvalidCells() && 
-									showHintCellValues[i] && 
+
+							boolean isFilteringCandidates =
+									isShowInvalidOrPossibleCells() &&
+									!isInvalidCells() &&
+									showHintCellValues[i] &&
 									Options.getInstance().isOnlySmallFilters();
-							
-							boolean isFilteringBivalueCandidates = 
-									sudoku.getValue(cellIndex) == 0 && 
+
+							boolean isFilteringBivalueCandidates =
+									sudoku.getValue(cellIndex) == 0 &&
 								    Options.getInstance().isOnlySmallFilters() &&
 								    isHighlightingBivalue &&
 								    isCellBivalue;
 
 							// highlight/filters candidates instead of cells
 							if (candidateValid && (isFilteringCandidates || isFilteringBivalueCandidates) && !isInvalidCells()) {
-							
+
 								if (isFilteringCandidates) {
 									setColor(g2, allBlack, Options.getInstance().getPossibleCellColor());
 								} else if (isFilteringBivalueCandidates) {
 									setColor(g2, allBlack, Options.getInstance().getPossibleCellColor());
 								}
-								
+
 								g2.fillRect(
 									(int) Math.round(startX + shiftX + third / 2.0 - ddy / 2.0),
 									(int) Math.round(startY + shiftY + third / 2.0 - ddy / 2.0),
@@ -2736,7 +2748,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 									(int) Math.round(ddy), (int) Math.round(ddy)
 								);
 							}
-							
+
 							if (hintColor != null) {
 								setColor(g2, allBlack, hintColor);
 								g2.fillOval(
@@ -2745,11 +2757,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 									(int) Math.round(ddy), (int) Math.round(ddy)
 								);
 							}
-							
+
 							setColor(g2, allBlack, candColor);
 							if (!Options.getInstance().isShowColorKuAct()) {
 								g2.drawString(
-									Integer.toString(i), 
+									Integer.toString(i),
 									(int) Math.round(startX + dcx + shiftX),
 									(int) Math.round(startY + dcy + shiftY)
 								);
@@ -2769,13 +2781,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		switch (Options.getInstance().getDrawMode()) {
 		case 0:
-			
+
 			if (allBlack) {
 				g2.setStroke(new BasicStroke(strokeWidth / 2));
 			} else {
 				g2.setStroke(new BasicStroke(strokeWidth));
 			}
-			
+
 			setColor(g2, allBlack, Options.getInstance().getInnerGridColor());
 			drawBlockLine(delta + gridRegion.x, 1 * delta + gridRegion.y, true);
 			drawBlockLine(delta + gridRegion.x, 2 * delta + gridRegion.y + 3 * cellSize, true);
@@ -2783,23 +2795,23 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			setColor(g2, allBlack, Options.getInstance().getGridColor());
 			g2.setStroke(new BasicStroke(boxStrokeWidth));
 			g2.drawRect(gridRegion.x, gridRegion.y, gridRegion.width, gridRegion.height);
-			
+
 			for (int i = 0; i < 3; i++) {
-				
+
 				g2.drawRect(
 					(i + 1) * delta + gridRegion.x + i * 3 * cellSize,
 					1 * delta + gridRegion.y,
 					3 * cellSize,
 					3 * cellSize
 				);
-				
+
 				g2.drawRect(
 					(i + 1) * delta + gridRegion.x + i * 3 * cellSize,
 					2 * delta + gridRegion.y + 3 * cellSize,
 					3 * cellSize,
 					3 * cellSize
 				);
-				
+
 				g2.drawRect(
 					(i + 1) * delta + gridRegion.x + i * 3 * cellSize,
 					3 * delta + gridRegion.y + 6 * cellSize,
@@ -2807,17 +2819,17 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					3 * cellSize
 				);
 			}
-			
+
 			break;
-			
+
 		case 1:
-			
+
 			if (allBlack) {
 				g2.setStroke(new BasicStroke(strokeWidth / 2));
 			} else {
 				g2.setStroke(new BasicStroke(strokeWidth));
 			}
-			
+
 			setColor(g2, allBlack, Options.getInstance().getInnerGridColor());
 			drawBlockLine(delta + gridRegion.x, 1 * delta + gridRegion.y, false);
 			drawBlockLine(delta + gridRegion.x, 2 * delta + gridRegion.y + 3 * cellSize, false);
@@ -2825,29 +2837,29 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			setColor(g2, allBlack, Options.getInstance().getGridColor());
 			g2.setStroke(new BasicStroke(boxStrokeWidth));
 			g2.drawRect(gridRegion.x, gridRegion.y, gridRegion.width, gridRegion.height);
-			
+
 			for (int i = 0; i < 3; i++) {
 				g2.drawLine(gridRegion.x, gridRegion.y + i * 3 * cellSize, gridRegion.x + Sudoku2.UNITS * cellSize, gridRegion.y + i * 3 * cellSize);
 				g2.drawLine(gridRegion.x + i * 3 * cellSize, gridRegion.y, gridRegion.x + i * 3 * cellSize, gridRegion.y + Sudoku2.UNITS * cellSize);
 			}
-			
+
 			break;
 		}
 
 		if (step != null && !step.getChains().isEmpty()) {
-			
+
 			points.clear();
 
 			for (int ci = 0; ci < step.getChainAnz(); ci++) {
-				
+
 				if (step.getType().isKrakenFish() && chainIndex == -1) {
 					continue;
 				}
-				
+
 				if (chainIndex != -1 && chainIndex != ci) {
 					continue;
 				}
-				
+
 				Chain chain = step.getChains().get(ci);
 				for (int i = chain.getStart(); i <= chain.getEnd(); i++) {
 					int che = Math.abs(chain.getChain()[i]);
@@ -2864,21 +2876,21 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			for (Candidate cand : step.getCandidatesToDelete()) {
 				points.add(getCandKoord(cand.getIndex(), cand.getValue(), cellSize));
 			}
 
 			for (int ai = 0; ai < step.getAlses().size(); ai++) {
-				
+
 				if (step.getType().isKrakenFish() && chainIndex == -1) {
 					continue;
 				}
-				
+
 				if (chainIndex != -1 && !alsToShow.contains(ai)) {
 					continue;
 				}
-				
+
 				AlsInSolutionStep als = step.getAlses().get(ai);
 				for (int i = 0; i < als.getIndices().size(); i++) {
 					int index = als.getIndices().get(i);
@@ -2890,15 +2902,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			}
 
 			for (int ci = 0; ci < step.getChainAnz(); ci++) {
-				
+
 				if (step.getType().isKrakenFish() && chainIndex == -1) {
 					continue;
 				}
-				
+
 				if (chainIndex != -1 && ci != chainIndex) {
 					continue;
 				}
-				
+
 				Chain chain = step.getChains().get(ci);
 				drawChain(g2, chain, cellSize, ddy, allBlack);
 			}
@@ -2949,7 +2961,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			int che = Math.abs(ch[i]);
 			points1.add(getCandKoord(Chain.getSCellIndex(che), Chain.getSCandidate(che), cellSize));
 		}
-		
+
 		Stroke oldStroke = g2.getStroke();
 		int oldChe = 0;
 		int oldIndex = 0;
@@ -2960,7 +2972,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				// end point of a net branch -> ignore
 				continue;
 			}
-			
+
 			index = i;
 			int che = Math.abs(ch[i]);
 			int che1 = Math.abs(ch[i + 1]);
@@ -2968,38 +2980,38 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				oldChe = che;
 				oldIndex = i;
 			}
-			
+
 			if (ch[i] == Integer.MIN_VALUE && ch[i + 1] < 0) {
 				che = oldChe;
 				index = oldIndex;
 			}
-			
+
 			if (ch[i] < 0 && ch[i + 1] > 0) {
 				che = oldChe;
 				index = oldIndex;
 			}
-			
+
 			if (Chain.getSCellIndex(che) == Chain.getSCellIndex(che1)) {
 				// same cell -> ignore
 				continue;
 			}
-			
+
 			setColor(g2, allBlack, Options.getInstance().getArrowColor());
 			if (Chain.isSStrong(che1)) {
 				g2.setStroke(strongLinkStroke);
 			} else {
 				g2.setStroke(weakLinkStroke);
 			}
-			
+
 			drawArrow(g2, index, i + 1, cellSize, ddy, points1);
 		}
-		
+
 		g2.setStroke(oldStroke);
 
 	}
 
 	private void drawArrow(Graphics2D g2, int index1, int index2, int cellSize, double ddy,	List<Point2D.Double> points1) {
-		
+
 		// calculate the start and end points for the arrow
 		Point2D.Double p1 = (java.awt.geom.Point2D.Double) (points1.get(index1).clone());
 		Point2D.Double p2 = (java.awt.geom.Point2D.Double) (points1.get(index2).clone());
@@ -3015,18 +3027,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		double dy1 = deltaY;
 		boolean doesIntersect = false;
 		for (int i = 0; i < points.size(); i++) {
-			
+
 			if (points.get(i).equals(points1.get(index1)) || points.get(i).equals(points1.get(index2))) {
 				continue;
 			}
-			
+
 			Point2D.Double point = points.get(i);
 			double dx2 = point.x - p1.x;
 			double dy2 = point.y - p1.y;
 
-			if (Math.signum(dx1) == Math.signum(dx2) && 
-				Math.signum(dy1) == Math.signum(dy2) && 
-				Math.abs(dx2) <= Math.abs(dx1) && 
+			if (Math.signum(dx1) == Math.signum(dx2) &&
+				Math.signum(dy1) == Math.signum(dy2) &&
+				Math.abs(dx2) <= Math.abs(dx1) &&
 				Math.abs(dy2) <= Math.abs(dy1)) {
 				if (dx1 == 0.0 || dy1 == 0.0 || Math.abs(dx1 / dy1 - dx2 / dy2) < epsilon) {
 					doesIntersect = true;
@@ -3044,14 +3056,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 		// draw the line of the arrow
 		if (doesIntersect) {
-			
+
 			double bezierLength = 20.0;
-			
+
 			// adjust for very short lines
 			if (length < 2.0 * ddy) {
 				bezierLength = length / 4.0;
 			}
-			
+
 			// the end points are rotated 45 degrees (counter clockwise for the
 			// start point, clockwise for the end point)
 			rotatePoint(points1.get(index1), p1, -Math.PI / 4.0);
@@ -3079,7 +3091,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			double cos = Math.cos(aAlpha);
 			double aX = p2.x - cos * arrowLength;
 			double aY = p2.y - sin * arrowLength;
-			
+
 			if (doesIntersect) {
 				// try to calculate the real intersection point of
 				// the bezier curve with the arrows middle line
@@ -3091,20 +3103,20 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				double[] tmpPoints = new double[6];
 				PathIterator pIt = cubicCurve.getPathIterator(null, 0.01);
 				while (!pIt.isDone()) {
-					
+
 					@SuppressWarnings("unused")
 					int type = pIt.currentSegment(tmpPoints);
 					double dist = p2.distance(tmpPoints[0], tmpPoints[1]);
-					
+
 					if (Math.abs(dist - arrowLength) < eps) {
 						eps = Math.abs(dist - arrowLength);
 						aXTemp = tmpPoints[0];
 						aYTemp = tmpPoints[1];
 					}
-					
+
 					pIt.next();
 				}
-				
+
 				// ok, closest point is now in aXTemp/aYTemp
 				aX = aXTemp;
 				aY = aYTemp;
@@ -3112,7 +3124,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				sin = Math.sin(aAlpha);
 				cos = Math.cos(aAlpha);
 			}
-			
+
 			double daX = sin * arrowHeight;
 			double daY = cos * arrowHeight;
 			arrow.reset();
@@ -3133,7 +3145,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param angle
 	 */
 	private void rotatePoint(Point2D.Double p1, Point2D.Double p2, double angle) {
-		
+
 		// translate p2 to 0/0
 		p2.x -= p1.x;
 		p2.y -= p1.y;
@@ -3143,7 +3155,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		double cosAngle = Math.cos(angle);
 		double xact = p2.x;
 		double yact = p2.y;
-		
+
 		p2.x = xact * cosAngle - yact * sinAngle;
 		p2.y = xact * sinAngle + yact * cosAngle;
 		p2.x += p1.x;
@@ -3160,11 +3172,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param ddy
 	 */
 	private void adjustEndPoints(Point2D.Double p1, Point2D.Double p2, double alpha, double ddy) {
-		
+
 		double tmpDelta = ddy / 2.0 + 4.0;
 		int pX = (int) (tmpDelta * Math.cos(alpha));
 		int pY = (int) (tmpDelta * Math.sin(alpha));
-		
+
 		p1.x += pX;
 		p1.y += pY;
 		p2.x -= pX;
@@ -3191,69 +3203,69 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	public int getX(int row, int col) {
-		
+
 		int x = col * cellSize + delta + gridRegion.x;
 		if (col > 2) {
 			x += delta;
 		}
-		
+
 		if (col > 5) {
 			x += delta;
 		}
-		
+
 		return x;
 	}
 
 	public int getY(int row, int col) {
-		
+
 		int y = row * cellSize + delta + gridRegion.y;
 		if (row > 2) {
 			y += delta;
 		}
-		
+
 		if (row > 5) {
 			y += delta;
 		}
-		
+
 		return y;
 	}
 
 	private int getRow(Point p) {
-		
+
 		double tmp = p.y - gridRegion.y - delta;
 		if ((tmp >= 3 * cellSize && tmp <= 3 * cellSize + delta)
 				|| (tmp >= 6 * cellSize + delta && tmp <= 6 * cellSize + 2 * delta)) {
 			return -1;
 		}
-		
+
 		if (tmp > 3 * cellSize) {
 			tmp -= delta;
 		}
-		
+
 		if (tmp > 6 * cellSize) {
 			tmp -= delta;
 		}
-		
+
 		return (int) Math.ceil((tmp / cellSize) - 1);
 	}
 
 	private int getCol(Point p) {
-		
+
 		double tmp = p.x - gridRegion.x - delta;
-		
+
 		if ((tmp >= 3 * cellSize && tmp <= 3 * cellSize + delta)
 				|| (tmp >= 6 * cellSize + delta && tmp <= 6 * cellSize + 2 * delta)) {
 			return -1;
 		}
-		
+
 		if (tmp > 3 * cellSize) {
 			tmp -= delta;
 		}
-		
+
 		if (tmp > 6 * cellSize) {
 			tmp -= delta;
 		}
-		
+
 		return (int) Math.ceil((tmp / cellSize) - 1);
 	}
 
@@ -3269,41 +3281,41 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return The number of a candidate, if a click could be confirmed, or else -1
 	 */
 	public int getCandidate(Point p, int row, int col) {
-		
+
 		// check if a cell was clicked
 		if (row < 0 || col < 0) {
 			// clicked between cells -> cant mean a candidate
 			return -1;
 		}
-		
+
 		// calculate the coordinates of the left upper corner of the cell
 		double startX = gridRegion.x + col * cellSize;
 		if (col > 2) {
 			startX += delta;
 		}
-		
+
 		if (col > 5) {
 			startX += delta;
 		}
-		
+
 		double startY = gridRegion.y + row * cellSize;
 		if (row > 2) {
 			startY += delta;
 		}
-		
+
 		if (row > 5) {
 			startY += delta;
 		}
-		
+
 		// now check if a candidate was clicked
 		int candidate = -1;
-		double cs3 = cellSize / 3.0;		
+		double cs3 = cellSize / 3.0;
 		double dx = cs3;
 		double leftDx = 0;
 
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 3; j++) {
-				
+
 				double sx = startX + i * cs3 + leftDx;
 				double sy = startY + j * cs3 + leftDx;
 
@@ -3314,32 +3326,32 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 			}
 		}
-		
+
 		return -1;
 	}
 
 	public void setActiveColor(Color color) {
-		
+
 		if (color == null) {
-			
+
 			// reset everything to normal
 			if (oldCursor != null) {
 				setCursor(oldCursor);
 				colorCursor = null;
 				colorCursorShift = null;
 			}
-			
+
 		} else {
-			
+
 			// create new Cursors and set them
 			if (oldCursor == null) {
 				oldCursor = getCursor();
 			}
-			
+
 			createColorCursors();
 			setCursor(colorCursor);
 		}
-		
+
 		// no region selects are allowed in coloring
 		clearRegion();
 		updateCellZoomPanel();
@@ -3358,11 +3370,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	private void drawBlock(int x, int y, boolean withRect) {
-		
+
 		if (withRect) {
 			g2.drawRect(x, y, 3 * cellSize, 3 * cellSize);
 		}
-		
+
 		g2.drawLine(x, y + 1 * cellSize, x + 3 * cellSize, y + 1 * cellSize);
 		g2.drawLine(x, y + 2 * cellSize, x + 3 * cellSize, y + 2 * cellSize);
 		g2.drawLine(x + 1 * cellSize, y, x + 1 * cellSize, y + 3 * cellSize);
@@ -3454,7 +3466,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		redoStack.clear();
 		coloringMap.clear();
 		resetShowHintCellValues();
-		
+
 		clearSelection();
 		clearDragSelection();
 		cellSelection.clear();
@@ -3531,7 +3543,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		}
 
 		updateCellZoomPanel();
-		
+
 		if (mainFrame != null) {
 			mainFrame.setCurrentLevel(sudoku.getLevel());
 			mainFrame.setCurrentScore(sudoku.getScore());
@@ -3555,14 +3567,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * solving stops, when the first training step has been reached.
 	 */
 	public void solveUpTo() {
-		
+
 		SolutionStep actStep = null;
 		boolean changed = false;
 		undoStack.push(sudoku.clone());
 		GameMode gm = Options.getInstance().getGameMode();
-		
+
 		while ((actStep = solver.getHint(sudoku, false)) != null) {
-			
+
 			if (actStep.isGiveUp()) {
 				// should display a message saying it failed, but I don;t know where the log UI is located.
 				break;
@@ -3577,12 +3589,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					break;
 				}
 			}
-			
+
 			// still here? do the step
 			getSolver().doStep(sudoku, actStep);
 			changed = true;
 		}
-			
+
 		/*
 		if (actStep.isGiveUp()) {
 			JOptionPane.showMessageDialog(
@@ -3593,13 +3605,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			);
 			break;
 		}*/
-		
+
 		if (changed) {
 			redoStack.clear();
 		} else {
 			undoStack.pop();
 		}
-		
+
 		step = null;
 		setChainInStep(-1);
 		updateCellZoomPanel();
@@ -3633,17 +3645,17 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	public void setChainInStep(int chainIndex) {
-		
+
 		if (step == null) {
 			chainIndex = -1;
 		} else if (step.getType().isKrakenFish() && chainIndex > -1) {
 			chainIndex--;
 		}
-		
+
 		if (chainIndex >= 0 && chainIndex > step.getChainAnz() - 1) {
 			chainIndex = -1;
 		}
-		
+
 		this.chainIndex = chainIndex;
 		alsToShow.clear();
 		if (chainIndex != -1) {
@@ -3659,9 +3671,9 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	public void doStep() {
-		
+
 		if (step != null) {
-			
+
 			undoStack.push(sudoku.clone());
 			redoStack.clear();
 			getSolver().doStep(sudoku, step);
@@ -3671,7 +3683,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			checkProgress();
 			mainFrame.check();
 			repaint();
-			
+
 			if (sudoku.isSolved() && Options.getInstance().isShowSudokuSolved()) {
 				JOptionPane.showMessageDialog(
 					this,
@@ -3723,7 +3735,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	public void setShowHintCellValue(int candidate) {
-		
+
 		if (candidate == 10) {
 			// filter bivalue cells
 			for (int i = 0; i < showHintCellValues.length - 1; i++) {
@@ -3768,13 +3780,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param fileName Pfad und Name der neuen Bilddatei
 	 */
 	private void writePNG(BufferedImage bi, int dpi, File file) {
-		
+
 		Iterator<ImageWriter> i = ImageIO.getImageWritersByFormatName("png");
 		// are there any jpeg encoders available?
 
 		// there's at least one ImageWriter, just use the first one
 		if (i.hasNext()) {
-			
+
 			ImageWriter imageWriter = i.next();
 			ImageWriteParam param = imageWriter.getDefaultWriteParam();
 			ImageTypeSpecifier its = new ImageTypeSpecifier(bi.getColorModel(), bi.getSampleModel());
@@ -3793,17 +3805,17 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				iomd.setFromTree(formatName, node);
 			} catch (IIOInvalidTreeException e) {
 				JOptionPane.showMessageDialog(
-					this, 
+					this,
 					e.getLocalizedMessage(),
 					java.util.ResourceBundle.getBundle("intl/SudokuPanel").getString("SudokuPanel.error"),
 					JOptionPane.ERROR_MESSAGE
 				);
 			}
-			
+
 			// attach the metadata to an image
 			IIOImage iioimage = new IIOImage(bi, null, iomd);
 			try {
-				
+
 				FileImageOutputStream out = new FileImageOutputStream(file);
 				imageWriter.setOutput(out);
 				imageWriter.write(iioimage);
@@ -3813,7 +3825,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				if (companionFileName.toLowerCase().endsWith(".png")) {
 					companionFileName = companionFileName.substring(0, companionFileName.length() - 4);
 				}
-				
+
 				companionFileName += ".txt";
 				PrintWriter cOut = new PrintWriter(new BufferedWriter(new FileWriter(companionFileName)));
 				cOut.println(getSudokuString(ClipboardMode.CLUES_ONLY));
@@ -3822,12 +3834,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				if (step != null) {
 					cOut.println(getSudokuString(ClipboardMode.PM_GRID_WITH_STEP));
 				}
-				
+
 				cOut.close();
-				
+
 			} catch (IOException e) {
 				JOptionPane.showMessageDialog(
-					this, 
+					this,
 					e.getLocalizedMessage(),
 					java.util.ResourceBundle.getBundle("intl/SudokuPanel").getString("SudokuPanel.error"),
 					JOptionPane.ERROR_MESSAGE
@@ -3845,7 +3857,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		Options.getInstance().setColorCells(colorCells);
 		updateCellZoomPanel();
 	}*/
-	
+
 	public void updateColorCursor() {
 		createColorCursors();
 		setCursor(colorCursor);
@@ -3857,9 +3869,9 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * stored in {@link #colorCursor} and {@link #colorCursorShift}.
 	 */
 	private void createColorCursors() {
-		
+
 		try {
-			
+
 			Point cursorHotSpot = new Point(2, 4);
 			BufferedImage img1 = ImageIO.read(getClass().getResource("/img/c_color.png"));
 			Graphics2D gImg1 = (Graphics2D) img1.getGraphics();
@@ -3874,7 +3886,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 
 			gImg2.fillRect(19, 18, 12, 12);
 			colorCursorShift = Toolkit.getDefaultToolkit().createCustomCursor(img2, cursorHotSpot, "c_weak");
-			
+
 		} catch (Exception ex) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Error creating color cursors", ex);
 		}
@@ -3889,19 +3901,19 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return
 	 */
 	private boolean isHiddenSingle(int candidate, int row, int col) {
-		
+
 		// sometimes the internal singles queues get corrupted
 		sudoku.rebuildInternalData();
 		SudokuStepFinder finder = SudokuSolverFactory.getDefaultSolverInstance().getStepFinder();
 		List<SolutionStep> steps = finder.findAllHiddenSingles(sudoku);
 		for (SolutionStep act : steps) {
-			if (act.getType() == SolutionType.HIDDEN_SINGLE && 
-				act.getValues().get(0) == candidate	&& 
+			if (act.getType() == SolutionType.HIDDEN_SINGLE &&
+				act.getValues().get(0) == candidate	&&
 				act.getIndices().get(0) == Sudoku2.getIndex(row, col)) {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
 
@@ -3910,7 +3922,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		/*
 		 * isCtrlDown was originally used to do two things: 1. toggle candidate
 		 * visibility on double click 2. toggle cell selection on single click
-		 * 
+		 *
 		 * Those functions don't leave any room for showCandidateHighlight. They
 		 * conflict together, and such, I should come up with a new mechanism to toggle
 		 * their state; however, for the time being, I will simply provide an option to
@@ -3928,14 +3940,14 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return
 	 */
 	public SudokuSet collectCandidates(boolean intersection) {
-		
+
 		SudokuSet resultSet = new SudokuSet();
 		SudokuSet tmpSet = new SudokuSet();
-		
+
 		if (intersection) {
 			resultSet.setAll();
 		}
-		
+
 		if (cellSelection.isEmpty()) {
 			if (sudoku.getValue(getActiveRow(), getActiveCol()) == 0) {
 				// get candidates only when cell is not set!
@@ -3962,12 +3974,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					}
 				}
 			}
-			
+
 			if (intersection && emptyCellsOnly) {
 				resultSet.clear();
 			}
 		}
-		
+
 		return resultSet;
 	}
 
@@ -3978,7 +3990,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return true if sudoku is changed, false otherwise
 	 */
 	public boolean removeCandidateFromCellSelection(int candidate) {
-		
+
 		boolean changed = false;
 		if (cellSelection.isEmpty()) {
 			System.err.println("Unexpected error in removeCandidateFromCellSelection, cellSelection should not be empty.");
@@ -3997,12 +4009,12 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 			}
 		}
-		
+
 		return changed;
 	}
 
 	public void toggleCandidateFromCellSelection(int candidate) {
-		
+
 		if (cellSelection.isEmpty()) {
 			System.err.println("Unexpected error in toggleCandidateFromCellSelection, cellSelection should not be empty.");
 			return;
@@ -4023,27 +4035,27 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @param candidate
 	 */
 	public void toggleCandidateFromCellZoomPanel(int candidate) {
-		
+
 		if (candidate != -1) {
-			
+
 			undoStack.push(sudoku.clone());
 			boolean changed = false;
-			
+
 			if (cellSelection.isEmpty()) {
-				System.err.println("Unexpected error in toggleCandidateFromCellZoomPanel, cellSelection should not be empty.");				
+				System.err.println("Unexpected error in toggleCandidateFromCellZoomPanel, cellSelection should not be empty.");
 				return;
 			} else {
 				toggleCandidateFromCellSelection(candidate);
 				changed = true;
 			}
-			
+
 			if (changed) {
 				redoStack.clear();
 				checkProgress();
 			} else {
 				undoStack.pop();
 			}
-			
+
 			updateCellZoomPanel();
 			mainFrame.check();
 			mainFrame.repaint();
@@ -4063,11 +4075,11 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	public void setCellZoomPanel(CellZoomPanel cellZoomPanel) {
 		this.cellZoomPanel = cellZoomPanel;
 	}
-	
+
 	public void clearCellColor(Color colorNumber) {
-		
-		for (int i = 0; i < Sudoku2.LENGTH; i++) {			
-			SortedMap<Integer, Color> map = coloringMap;			
+
+		for (int i = 0; i < Sudoku2.LENGTH; i++) {
+			SortedMap<Integer, Color> map = coloringMap;
 			if (map.containsKey(i) && map.get(i) == colorNumber) {
 				map.remove(i);
 			}
@@ -4076,32 +4088,32 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		updateCellZoomPanel();
 		repaint();
 	}
-	
-	
+
+
 	public void clearCandidateColor(Color colorNumber) {
 
 		SortedMap<Integer, Color> map = coloringCandidateMap;
 		for (int index = 0; index < Sudoku2.LENGTH; index++) {
 			for (int candidate = 1; candidate <= Sudoku2.UNITS; candidate++) {
-				int key = index * 10 + candidate;				
+				int key = index * 10 + candidate;
 				if (map.containsKey(key) && map.get(key) == colorNumber) {
 					map.remove(key);
-				}		
+				}
 			}
 		}
-		
+
 		updateCellZoomPanel();
 		repaint();
 	}
 
 	public void updateCellZoomPanel() {
-		
+
 		if (cellZoomPanel == null) {
 			return;
 		}
-		
+
 		if (cellZoomPanel.isColoring()) {
-			
+
 			cellZoomPanel.update(
 				SudokuSetBase.EMPTY_SET,
 				SudokuSetBase.EMPTY_SET,
@@ -4110,13 +4122,13 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				null,
 				null
 			);
-			
+
 			return;
 		}
-		
+
 		int index = Sudoku2.getIndex(getActiveRow(), getActiveCol());
 		boolean singleCell = cellSelection.isEmpty() && sudoku.getValue(index) == 0;
-		
+
 		if (cellZoomPanel.isDefaultMouse()) {
 			// normal operation -> collect candidates for selected cell(s)
 			if (sudoku.getValue(index) != 0 && cellSelection.isEmpty()) {
@@ -4129,24 +4141,24 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					null,
 					null
 				);
-				
+
 			} else {
-				
+
 				SudokuSet valueSet = collectCandidates(true);
 				SudokuSet candSet = collectCandidates(false);
-				
+
 				cellZoomPanel.update(
-					valueSet, 
-					candSet, 
-					index, 
-					singleCell, 
-					null, 
+					valueSet,
+					candSet,
+					index,
+					singleCell,
+					null,
 					null
 				);
 			}
-			
+
 		} else {
-			
+
 			if (!cellSelection.isEmpty() || (cellSelection.isEmpty() && sudoku.getValue(index) != 0)) {
 				// no coloring, when set of cells is selected
 				cellZoomPanel.update(
@@ -4157,15 +4169,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 					null,
 					null
 				);
-				
+
 			} else {
-				
+
 				SudokuSet valueSet = collectCandidates(true);
 				SudokuSet candSet = collectCandidates(false);
-				
+
 				cellZoomPanel.update(
-					valueSet, 
-					candSet, 
+					valueSet,
+					candSet,
 					index,
 					singleCell,
 					coloringMap,
@@ -4195,7 +4207,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * progress check is scheduled.<br>
 	 */
 	public void checkProgress() {
-		
+
 		int anz = sudoku.getSolvedCellsAnz();
 
 		if (anz == 0) {
@@ -4205,8 +4217,8 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			sudoku.setStatus(SudokuStatus.INVALID);
 			sudoku.setStatusGivens(SudokuStatus.INVALID);
 		} else {
-			
-			if (sudoku.checkSudoku()) {				
+
+			if (sudoku.checkSudoku()) {
 				// we have to check!
 				int anzSol = generator.getNumberOfSolutions(sudoku, 1000);
 				sudoku.setStatus(anzSol);
@@ -4216,7 +4228,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				if (anzSol == 1) {
 					// the sudoku is valid -> check the progress
 					progressChecker.startCheck(sudoku);
-				}	
+				}
 			}
 		}
 	}
@@ -4229,7 +4241,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return
 	 */
 	private int getShowHintCellValue() {
-		
+
 		int value = 0;
 		for (int i = 1; i < showHintCellValues.length - 1; i++) {
 			if (showHintCellValues[i]) {
@@ -4241,7 +4253,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 				}
 			}
 		}
-		
+
 		return value;
 	}
 
@@ -4253,7 +4265,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 			}
 		}
 	}
-	
+
 	public void setColorIconsInPopupMenu() {
 		rightClickMenu.setColorIconsInPopupMenu();
 	}
@@ -4264,7 +4276,7 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 		updateCellZoomPanel();
 		repaint();
 	}
-	
+
 	public void setColorsVisible(boolean isVisible) {
 		isColoringVisible = isVisible;
 	}
@@ -4277,15 +4289,15 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	}
 
 	private void drawColorBox(int n, Graphics gc, int cx, int cy, int boxSize, boolean large) {
-		
+
 		BufferedImage[] images = null;
-		
+
 		if (large) {
 			images = colorKuImagesLarge;
 		} else {
 			images = colorKuImagesSmall;
 		}
-		
+
 		if (images[0] == null || images[0].getWidth() != boxSize) {
 			for (int i = 0; i < images.length; i++) {
 				images[i] = new ColorKuImage(boxSize, Options.getInstance().getColorKuColor(i + 1));
@@ -4310,18 +4322,18 @@ public class SudokuPanel extends javax.swing.JPanel implements Printable {
 	 * @return
 	 */
 	public boolean[] getRemainingCandidates() {
-		
+
 		for (int i = 0; i < remainingCandidates.length; i++) {
 			remainingCandidates[i] = false;
 		}
-		
+
 		if (isShowCandidates()) {
 			final int[] cands = Sudoku2.POSSIBLE_VALUES[sudoku.getRemainingCandidates()];
 			for (int i = 0; i < cands.length; i++) {
 				remainingCandidates[cands[i] - 1] = true;
 			}
 		}
-		
+
 		return remainingCandidates;
 	}
 


### PR DESCRIPTION
- The coloring bar at bottom did not work with the pseudofish changes. Now it does.
- Escape did not work to clear the colors and reset the mode, now it does.
- the R on the bottom now also works.
- 'T' now toggles between the 3 different coloring modes.